### PR TITLE
Task 2: Configure Astro (i18n + Vercel adapter + integrations)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ npm-debug.log*
 # Claude Code — local-only overrides
 .claude/settings.local.json
 
+# Git worktrees
+.worktrees/
+

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,31 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
+import vercel from '@astrojs/vercel';
+
+export default defineConfig({
+  site: process.env.PUBLIC_SITE_URL || 'http://localhost:4321',
+  output: 'static',
+  adapter: vercel({ webAnalytics: { enabled: true } }),
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'pt-br'],
+    routing: {
+      prefixDefaultLocale: false,
+      redirectToDefaultLocale: false,
+      fallbackType: 'redirect',
+    },
+    fallback: { 'pt-br': 'en' },
+  },
+  integrations: [
+    tailwind({ applyBaseStyles: false }),
+    mdx(),
+    sitemap({
+      i18n: {
+        defaultLocale: 'en',
+        locales: { en: 'en-US', 'pt-br': 'pt-BR' },
+      },
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- Add `astro.config.mjs` with `output: 'static'`, `@astrojs/vercel` adapter, and Tailwind/MDX/sitemap integrations.
- Configure i18n with locales `['en', 'pt-br']`, `prefixDefaultLocale: false`, and `pt-br -> en` fallback.

## Test plan
- [x] `npx astro check` — 0 errors, 0 warnings, 0 hints

Closes #4