### PR TITLE
Task 3: Configure Tailwind with DESIGN.md tokens

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html {
+    font-family: theme('fontFamily.sans');
+    color: theme('colors.dark-charcoal');
+    background: theme('colors.white');
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  *:focus-visible {
+    outline: 3px solid theme('colors.brand-blue.DEFAULT');
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+}
+
+@layer utilities {
+  .container-wide {
+    max-width: theme('maxWidth.container');
+    margin-inline: auto;
+    padding-inline: 24px;
+  }
+
+  @media (min-width: 1024px) {
+    .container-wide {
+      padding-inline: 40px;
+    }
+  }
+}
+
+/* Site-wide reduced motion: disables non-essential animation */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,63 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  theme: {
+    extend: {
+      colors: {
+        'brand-blue': {
+          DEFAULT: '#0064E0',
+          hover: '#0143B5',
+          pressed: '#004BB9',
+          light: '#47A5FA',
+        },
+        'dark-charcoal': '#1C2B33',
+        'slate-gray': '#5D6C7B',
+        'soft-gray': '#F1F4F7',
+        'warm-gray': '#F7F8FA',
+        'baby-blue': '#E8F3FF',
+        'near-black': '#1C1E21',
+        'divider': '#DEE3E9',
+        'cta-disabled': '#DEE3E9',
+        'cta-disabled-text': '#8595A4',
+        'success': '#007D1E',
+        'success-bg': 'rgba(0,125,30,0.08)',
+        'error': '#C80A28',
+        'error-bg': 'rgba(200,10,40,0.08)',
+        'warning': '#F7B928',
+      },
+      fontFamily: {
+        sans: ['Montserrat', 'Helvetica', 'Arial', 'sans-serif'],
+      },
+      fontSize: {
+        'display-1': ['64px', { lineHeight: '1.16', fontWeight: '500' }],
+        'display-2': ['48px', { lineHeight: '1.17', fontWeight: '500' }],
+        'h1':        ['36px', { lineHeight: '1.28', fontWeight: '500' }],
+        'h2':        ['28px', { lineHeight: '1.21', fontWeight: '300' }],
+        'h3':        ['18px', { lineHeight: '1.44', fontWeight: '700' }],
+        'body':      ['18px', { lineHeight: '1.44', fontWeight: '400' }],
+        'compact':   ['16px', { lineHeight: '1.50', fontWeight: '500', letterSpacing: '-0.01em' }],
+        'caption':   ['14px', { lineHeight: '1.43', fontWeight: '400', letterSpacing: '-0.01em' }],
+        'small':     ['12px', { lineHeight: '1.33', fontWeight: '400' }],
+      },
+      borderRadius: {
+        'input': '8px',
+        'card': '20px',
+        'feature': '24px',
+        'pill': '100px',
+      },
+      spacing: {
+        'section-sm': '48px',
+        'section': '64px',
+        'section-lg': '80px',
+      },
+      boxShadow: {
+        'card': '0 2px 4px rgba(0,0,0,0.10)',
+        'card-elevated': '0 12px 28px rgba(0,0,0,0.20), 0 2px 4px rgba(0,0,0,0.10)',
+      },
+      maxWidth: {
+        container: '1440px',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- Adds `tailwind.config.mjs` extending theme with DESIGN.md tokens: Brand Blue + status colors, Montserrat type scale, radii (`input/card/feature/pill`), section spacing, elevation, container max-width.
- Adds `src/styles/global.css` with Montserrat import, Tailwind layers, base html/body, global `*:focus-visible` ring, `.container-wide` utility, and site-wide `prefers-reduced-motion` handling.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [ ] Visual verification deferred until UI primitives land (no pages exist yet)

Closes #10