### PR TITLE
feat(i18n): add string dictionaries and t() helper

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,60 @@
+{
+  "site": {
+    "name": "Syncologic",
+    "tagline": "Move files between clouds without downloading them first."
+  },
+  "nav": {
+    "useCases": "Use cases",
+    "pricing": "Pricing",
+    "selfHosted": "Self-hosted",
+    "developers": "Developers",
+    "joinWaitlist": "Join the waitlist",
+    "menu": "Menu",
+    "close": "Close"
+  },
+  "footer": {
+    "product": "Product",
+    "resources": "Resources",
+    "company": "Company",
+    "copyright": "© {year} Syncologic"
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "pt-br": "Português (Brasil)"
+  },
+  "waitlist": {
+    "emailLabel": "Email",
+    "emailPlaceholder": "you@example.com",
+    "submit": "Join the waitlist",
+    "submitting": "Joining…",
+    "success": "✓ You're on the list",
+    "errorNetwork": "Couldn't reach the server. Try again?",
+    "errorRate": "Slow down — try again in a minute.",
+    "step2Title": "Help us build this for you",
+    "step2Skip": "Skip — finish later",
+    "step2Done": "Done",
+    "questionUseCase": "What are you trying to move?",
+    "questionSourceProvider": "Where do the files live now?",
+    "questionDestProvider": "Where do they need to go?",
+    "questionSize": "How much data?",
+    "questionFrequency": "How often?",
+    "questionRunner": "Where should the transfer run?",
+    "questionRole": "Which best describes you?"
+  },
+  "providers": {
+    "googleDrive": "Google Drive",
+    "oneDrive": "OneDrive",
+    "dropbox": "Dropbox",
+    "s3": "S3-compatible storage",
+    "sftp": "SFTP",
+    "webdav": "WebDAV",
+    "nextcloud": "Nextcloud",
+    "other": "Other"
+  },
+  "runners": {
+    "cloud": { "name": "Cloud Runner", "tagline": "Hosted convenience" },
+    "browser": { "name": "Browser Runner", "tagline": "Run it in a tab" },
+    "private": { "name": "Private Runner", "tagline": "Your machine, your bandwidth" }
+  }
+}

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -1,0 +1,60 @@
+{
+  "site": {
+    "name": "Syncologic",
+    "tagline": "Move files between clouds without downloading them first."
+  },
+  "nav": {
+    "useCases": "Use cases",
+    "pricing": "Pricing",
+    "selfHosted": "Self-hosted",
+    "developers": "Developers",
+    "joinWaitlist": "Join the waitlist",
+    "menu": "Menu",
+    "close": "Close"
+  },
+  "footer": {
+    "product": "Product",
+    "resources": "Resources",
+    "company": "Company",
+    "copyright": "© {year} Syncologic"
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "pt-br": "Português (Brasil)"
+  },
+  "waitlist": {
+    "emailLabel": "Email",
+    "emailPlaceholder": "you@example.com",
+    "submit": "Join the waitlist",
+    "submitting": "Joining…",
+    "success": "✓ You're on the list",
+    "errorNetwork": "Couldn't reach the server. Try again?",
+    "errorRate": "Slow down — try again in a minute.",
+    "step2Title": "Help us build this for you",
+    "step2Skip": "Skip — finish later",
+    "step2Done": "Done",
+    "questionUseCase": "What are you trying to move?",
+    "questionSourceProvider": "Where do the files live now?",
+    "questionDestProvider": "Where do they need to go?",
+    "questionSize": "How much data?",
+    "questionFrequency": "How often?",
+    "questionRunner": "Where should the transfer run?",
+    "questionRole": "Which best describes you?"
+  },
+  "providers": {
+    "googleDrive": "Google Drive",
+    "oneDrive": "OneDrive",
+    "dropbox": "Dropbox",
+    "s3": "S3-compatible storage",
+    "sftp": "SFTP",
+    "webdav": "WebDAV",
+    "nextcloud": "Nextcloud",
+    "other": "Other"
+  },
+  "runners": {
+    "cloud": { "name": "Cloud Runner", "tagline": "Hosted convenience" },
+    "browser": { "name": "Browser Runner", "tagline": "Run it in a tab" },
+    "private": { "name": "Private Runner", "tagline": "Your machine, your bandwidth" }
+  }
+}

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,0 +1,49 @@
+import en from './en.json';
+import ptBr from './pt-br.json';
+
+export type Locale = 'en' | 'pt-br';
+export const LOCALES: Locale[] = ['en', 'pt-br'];
+export const DEFAULT_LOCALE: Locale = 'en';
+
+const dictionaries: Record<Locale, unknown> = { en, 'pt-br': ptBr };
+
+export function getLocaleFromUrl(url: URL): Locale {
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments[0] === 'pt-br') return 'pt-br';
+  return 'en';
+}
+
+export function pathWithoutLocale(pathname: string): string {
+  if (pathname.startsWith('/pt-br/')) return pathname.slice('/pt-br'.length);
+  if (pathname === '/pt-br') return '/';
+  return pathname;
+}
+
+export function localizedPath(locale: Locale, pathname: string): string {
+  const stripped = pathWithoutLocale(pathname);
+  if (locale === 'en') return stripped;
+  return stripped === '/' ? '/pt-br/' : `/pt-br${stripped}`;
+}
+
+function lookup(dict: unknown, key: string): string {
+  return (
+    (key.split('.').reduce<unknown>((acc, segment) => {
+      if (acc && typeof acc === 'object' && segment in (acc as Record<string, unknown>)) {
+        return (acc as Record<string, unknown>)[segment];
+      }
+      return undefined;
+    }, dict) as string | undefined) ?? key
+  );
+}
+
+function interpolate(value: string, vars: Record<string, string | number>): string {
+  return value.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? `{${name}}`));
+}
+
+export function getT(locale: Locale) {
+  const dict = dictionaries[locale];
+  return (key: string, vars?: Record<string, string | number>): string => {
+    const value = lookup(dict, key);
+    return vars ? interpolate(value, vars) : value;
+  };
+}


### PR DESCRIPTION
## Summary
- Add `src/i18n/en.json` + `src/i18n/pt-br.json` with the canonical key tree (site, nav, footer, language, waitlist, providers, runners). pt-BR ships English placeholder per Plan 1; Plan 3 will replace with real translations.
- Add `src/i18n/utils.ts` exporting `Locale`, `LOCALES`, `DEFAULT_LOCALE`, `getLocaleFromUrl`, `pathWithoutLocale`, `localizedPath`, and `getT` (dotted-key lookup + `{var}` interpolation).

## Test plan
- [x] `npm run lint` (astro check) — 0 errors / 0 warnings
- [ ] Vitest unit tests for `utils.ts` — out of scope per parent issue (covered by broader testing pass)
- [ ] End-to-end consumption — first page using `getT` will exercise the helpers

Closes #16
Closes #31
Closes #32