### PR TITLE
feat(ui): Button primitive (primary/secondary/ghost)

### DIFF
--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,0 +1,55 @@
+---
+type Variant = 'primary' | 'secondary' | 'ghost';
+type Size = 'sm' | 'md' | 'lg';
+
+interface Props {
+  variant?: Variant;
+  size?: Size;
+  href?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  class?: string;
+  ariaLabel?: string;
+}
+
+const {
+  variant = 'primary',
+  size = 'md',
+  href,
+  type = 'button',
+  disabled = false,
+  class: extra = '',
+  ariaLabel,
+} = Astro.props;
+
+const base =
+  'inline-flex items-center justify-center rounded-pill font-medium transition-all duration-200 focus-visible:outline-none disabled:cursor-not-allowed';
+
+const variants: Record<Variant, string> = {
+  primary:
+    'bg-brand-blue text-white hover:bg-brand-blue-hover active:bg-brand-blue-pressed disabled:bg-cta-disabled disabled:text-cta-disabled-text',
+  secondary:
+    'bg-transparent text-dark-charcoal border-2 border-[rgba(10,19,23,0.12)] hover:bg-[rgba(70,90,105,0.08)]',
+  ghost: 'bg-transparent text-brand-blue hover:underline',
+};
+
+const sizes: Record<Size, string> = {
+  sm: 'px-4 py-2 text-caption',
+  md: 'px-[22px] py-[10px] text-caption',
+  lg: 'px-7 py-3 text-compact',
+};
+
+const classes = [base, variants[variant], sizes[size], extra].join(' ');
+const Tag = href ? 'a' : 'button';
+---
+
+<Tag
+  class={classes}
+  href={href}
+  type={!href ? type : undefined}
+  disabled={!href ? disabled : undefined}
+  aria-label={ariaLabel}
+  aria-disabled={disabled ? 'true' : undefined}
+>
+  <slot />
+</Tag>


### PR DESCRIPTION
## Summary
- Adds `src/components/ui/Button.astro` per DESIGN.md pill-CTA contract
- Three variants (primary / secondary / ghost) and three sizes (sm / md / lg)
- Renders `<a>` when `href` is set, `<button>` otherwise; passes through `type`, `disabled`, `aria-label`

## Test plan
- [x] `npm run lint` (astro check) — 0 errors / 0 warnings
- [ ] Visual verification deferred — primitive is unused until composed in later tasks

Closes #22