### PR TITLE
feat(ui): add Card primitive (Task 6)

### DIFF
--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -1,0 +1,31 @@
+---
+type Radius = 'card' | 'feature';
+type Elevation = 'flat' | 'card' | 'elevated';
+
+interface Props {
+  radius?: Radius;
+  elevation?: Elevation;
+  class?: string;
+  as?: 'div' | 'article' | 'section';
+}
+
+const { radius = 'card', elevation = 'flat', class: extra = '', as = 'div' } = Astro.props as Props;
+
+const radii: Record<Radius, string> = {
+  card: 'rounded-card',
+  feature: 'rounded-feature',
+};
+
+const elevations: Record<Elevation, string> = {
+  flat: '',
+  card: 'shadow-card',
+  elevated: 'shadow-card-elevated',
+};
+
+const classes = ['bg-white border border-divider', radii[radius], elevations[elevation], extra]
+  .filter(Boolean)
+  .join(' ');
+const Tag = as;
+---
+
+<Tag class={classes}><slot /></Tag>


### PR DESCRIPTION
## Summary
- Adds `src/components/ui/Card.astro` with `radius` (`card` | `feature`), `elevation` (`flat` | `card` | `elevated`), `as`, and pass-through `class` props.
- Defaults: `radius='card'`, `elevation='flat'`, `as='div'`. Uses design-system tokens (`rounded-card`, `rounded-feature`, `shadow-card`, `shadow-card-elevated`, `border-divider`).

## Test plan
- [x] `npm run lint` clean (astro check, 0 errors).
- [ ] Visual verification deferred — primitive has no consumers yet (homepage assembly is #26). Will be exercised when sections start consuming it.

Closes #2