### PR TITLE
feat(ui): add Input primitive + vitest config

### DIFF
--- a/src/components/ui/Input.astro
+++ b/src/components/ui/Input.astro
@@ -1,0 +1,52 @@
+---
+interface Props {
+  type?: 'text' | 'email' | 'tel';
+  name: string;
+  id?: string;
+  placeholder?: string;
+  value?: string;
+  required?: boolean;
+  autocomplete?: string;
+  ariaLabel?: string;
+  ariaDescribedBy?: string;
+  ariaInvalid?: boolean;
+  class?: string;
+}
+
+const {
+  type = 'text',
+  name,
+  id,
+  placeholder,
+  value,
+  required,
+  autocomplete,
+  ariaLabel,
+  ariaDescribedBy,
+  ariaInvalid,
+  class: extra = '',
+} = Astro.props;
+
+const classes = [
+  'w-full px-4 py-3 bg-white border border-divider rounded-input text-compact text-dark-charcoal',
+  'placeholder:text-slate-gray',
+  'focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/30 focus:outline-none',
+  'aria-[invalid=true]:border-error aria-[invalid=true]:ring-error/30',
+  'transition-colors duration-200',
+  extra,
+].join(' ');
+---
+
+<input
+  type={type}
+  name={name}
+  id={id ?? name}
+  placeholder={placeholder}
+  value={value}
+  required={required}
+  autocomplete={autocomplete}
+  aria-label={ariaLabel}
+  aria-describedby={ariaDescribedBy}
+  aria-invalid={ariaInvalid ? 'true' : undefined}
+  class={classes}
+/>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/__tests__/**/*.test.ts'],
+    globals: false,
+  },
+  resolve: {
+    alias: { '@': '/src' },
+  },
+});


### PR DESCRIPTION
Closes #5

## Summary
- Add `src/components/ui/Input.astro` — token-driven primitive supporting `text`/`email`/`tel` with ARIA props, brand-blue focus ring, and error-aware styling via `aria-[invalid=true]`.
- Add `vitest.config.ts` — Node env, `src/**/__tests__/**/*.test.ts` glob, `@/` → `/src` alias. Stands up the test runner ahead of upcoming i18n / HMAC / validation tests.

## Test plan
- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `npm test` — config loads (no tests yet, exits as expected)
- [ ] Visual verification in browser deferred — primitive has no consumer page yet; will be exercised when WaitlistForm lands.