### PR TITLE
feat(layout): Footer + Supabase waitlist migration

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,0 +1,48 @@
+---
+import { getLocaleFromUrl, getT, localizedPath } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const year = new Date().getFullYear();
+const pathname = Astro.url.pathname;
+---
+
+<footer class="bg-soft-gray border-t border-divider">
+  <div class="container-wide py-section">
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
+      <div class="col-span-2 md:col-span-1">
+        <a href={localizedPath(locale, '/')} class="flex items-center gap-2 mb-4">
+          <img src="/assets/brand/icon-black.png" alt={t('site.name')} width="32" height="32" class="rounded-input" />
+          <span class="text-compact font-medium">{t('site.name').toLowerCase()}</span>
+        </a>
+        <p class="text-caption text-slate-gray max-w-xs">{t('site.tagline')}</p>
+      </div>
+
+      <div>
+        <h3 class="text-caption font-medium uppercase tracking-wide text-slate-gray mb-3">{t('footer.product')}</h3>
+        <ul class="space-y-2 text-caption">
+          <li><a href={localizedPath(locale, '/pricing')} class="hover:underline">{t('nav.pricing')}</a></li>
+          <li><a href={localizedPath(locale, '/self-hosted')} class="hover:underline">{t('nav.selfHosted')}</a></li>
+          <li><a href={localizedPath(locale, '/developers')} class="hover:underline">{t('nav.developers')}</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3 class="text-caption font-medium uppercase tracking-wide text-slate-gray mb-3">{t('footer.resources')}</h3>
+        <ul class="space-y-2 text-caption">
+          <li><a href={localizedPath(locale, '/use-cases/cloud-to-cloud-transfer')} class="hover:underline">{t('nav.useCases')}</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3 class="text-caption font-medium uppercase tracking-wide text-slate-gray mb-3">{t('language.label')}</h3>
+        <ul class="space-y-2 text-caption">
+          <li><a href={localizedPath('en', pathname)} class="hover:underline" hreflang="en">{t('language.en')}</a></li>
+          <li><a href={localizedPath('pt-br', pathname)} class="hover:underline" hreflang="pt-br">{t('language.pt-br')}</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="text-small text-slate-gray mt-12">{t('footer.copyright', { year })}</p>
+  </div>
+</footer>

--- a/supabase/migrations/20260429000000_waitlist.sql
+++ b/supabase/migrations/20260429000000_waitlist.sql
@@ -16,7 +16,7 @@ create table if not exists waitlist (
   user_agent                  text,
   referrer                    text,
   ip_hash                     text,
-  unsubscribe_token           text default encode(gen_random_bytes(16), 'hex'),
+  unsubscribe_token           text default encode(extensions.gen_random_bytes(16), 'hex'),
   segmentation_completed_at   timestamptz,
   removed_at                  timestamptz,
   confirmed_at                timestamptz,

--- a/supabase/migrations/20260429000000_waitlist.sql
+++ b/supabase/migrations/20260429000000_waitlist.sql
@@ -1,0 +1,52 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists waitlist (
+  id                          uuid primary key default gen_random_uuid(),
+  email                       text not null unique,
+  source_page                 text,
+  segment_hint                text,
+  locale                      text default 'en',
+  use_case                    text,
+  source_provider             text,
+  dest_provider               text,
+  est_size                    text,
+  frequency                   text,
+  preferred_runner            text,
+  role                        text,
+  user_agent                  text,
+  referrer                    text,
+  ip_hash                     text,
+  unsubscribe_token           text default encode(gen_random_bytes(16), 'hex'),
+  segmentation_completed_at   timestamptz,
+  removed_at                  timestamptz,
+  confirmed_at                timestamptz,
+  created_at                  timestamptz default now(),
+  updated_at                  timestamptz default now()
+);
+
+create index if not exists waitlist_use_case_idx on waitlist(use_case);
+create index if not exists waitlist_locale_idx   on waitlist(locale);
+create index if not exists waitlist_created_idx  on waitlist(created_at desc);
+create index if not exists waitlist_unsub_idx    on waitlist(unsubscribe_token);
+
+create or replace function set_updated_at() returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists waitlist_updated_at on waitlist;
+create trigger waitlist_updated_at
+  before update on waitlist
+  for each row execute function set_updated_at();
+
+alter table waitlist enable row level security;
+
+drop policy if exists waitlist_insert_anon on waitlist;
+create policy waitlist_insert_anon on waitlist
+  for insert with check (false);
+
+drop policy if exists waitlist_service_all on waitlist;
+create policy waitlist_service_all on waitlist
+  for all to service_role using (true) with check (true);


### PR DESCRIPTION
## Summary
- Adds `src/components/layout/Footer.astro` — soft-gray footer, 4-column grid (brand, Product, Resources, Language), copyright with year interpolation, locale-aware links via `localizedPath`.
- Adds `supabase/migrations/20260429000000_waitlist.sql` — `waitlist` table with all segmentation columns, `pgcrypto`, indexes (`use_case`, `locale`, `created_at`, `unsubscribe_token`), `set_updated_at` trigger, RLS enabled (default deny + `service_role` policy).

Implements plan Task 13 (`docs/superpowers/plans/2026-04-29-foundation-and-homepage.md`, lines 1240–1367).

## Test plan
- [x] `npm run lint` (astro check) — 0 errors
- [x] `npm test` — 15/15 passing
- [ ] Apply migration to Supabase (dashboard SQL Editor or `supabase db push`) — **deferred to maintainer**, requires service-role credentials
- [ ] Visual verification of Footer at `/` and `/pt-br/` — not performed; Footer is not yet wired into a rendered page (Layout exposes a `footer` slot; pages will fill it in later tasks)

Closes #11
Closes #33
Closes #34