### PR TITLE
feat(lib): HMAC sign/verify for waitlist row tokens

### DIFF
--- a/src/lib/__tests__/hmac.test.ts
+++ b/src/lib/__tests__/hmac.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { signToken, verifyToken } from '../hmac';
+
+beforeAll(() => {
+  if (!import.meta.env.WAITLIST_TOKEN_SECRET) {
+    process.env.WAITLIST_TOKEN_SECRET = 'a'.repeat(64);
+  }
+});
+
+describe('hmac', () => {
+  it('signs and verifies a valid token', () => {
+    const token = signToken('row-123');
+    expect(verifyToken('row-123', token)).toBe(true);
+  });
+
+  it('rejects a token for a different id', () => {
+    const token = signToken('row-123');
+    expect(verifyToken('row-456', token)).toBe(false);
+  });
+
+  it('rejects a tampered token', () => {
+    const token = signToken('row-123');
+    const tampered = token.slice(0, -2) + 'XX';
+    expect(verifyToken('row-123', tampered)).toBe(false);
+  });
+
+  it('signs same id deterministically', () => {
+    expect(signToken('row-1')).toBe(signToken('row-1'));
+  });
+});

--- a/src/lib/hmac.ts
+++ b/src/lib/hmac.ts
@@ -1,0 +1,20 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function getSecret(): string {
+  const s = import.meta.env.WAITLIST_TOKEN_SECRET ?? process.env.WAITLIST_TOKEN_SECRET;
+  if (!s) throw new Error('WAITLIST_TOKEN_SECRET is required');
+  return s;
+}
+
+export function signToken(rowId: string): string {
+  return createHmac('sha256', getSecret()).update(rowId).digest('hex');
+}
+
+export function verifyToken(rowId: string, token: string): boolean {
+  if (!/^[0-9a-f]{64}$/i.test(token)) return false;
+  const expected = signToken(rowId);
+  const a = Buffer.from(token, 'hex');
+  const b = Buffer.from(expected, 'hex');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/hmac.ts` exporting `signToken(rowId)` / `verifyToken(rowId, token)`, backed by `WAITLIST_TOKEN_SECRET` and `timingSafeEqual`.
- 4 Vitest cases cover happy path, wrong id, tampered token, and determinism.

Implements Task 17 of `docs/superpowers/plans/2026-04-29-foundation-and-homepage.md`.

## Test plan
- [x] `npm test -- src/lib/__tests__/hmac` (4/4 passing)
- [x] `npm run lint` (0 errors)
- [x] Full `npm test` suite (19/19 passing)

Closes #9