### PR TITLE
feat(lib): zod validation schemas for waitlist (Task 18)

### DIFF
--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { waitlistPostSchema, waitlistPatchSchema } from '../validation';
+
+describe('waitlistPostSchema', () => {
+  it('accepts a valid signup', () => {
+    const r = waitlistPostSchema.safeParse({ email: 'a@b.test', locale: 'en' });
+    expect(r.success).toBe(true);
+  });
+  it('rejects bad email', () => {
+    expect(waitlistPostSchema.safeParse({ email: 'not-an-email', locale: 'en' }).success).toBe(false);
+  });
+  it('rejects unknown locale', () => {
+    expect(waitlistPostSchema.safeParse({ email: 'a@b.test', locale: 'fr' }).success).toBe(false);
+  });
+  it('rejects unknown fields', () => {
+    const r = waitlistPostSchema.safeParse({ email: 'a@b.test', locale: 'en', evil: 'x' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('waitlistPatchSchema', () => {
+  it('accepts valid use_case', () => {
+    expect(waitlistPatchSchema.safeParse({ use_case: 'business_migration' }).success).toBe(true);
+  });
+  it('rejects invalid use_case', () => {
+    expect(waitlistPatchSchema.safeParse({ use_case: 'bogus' }).success).toBe(false);
+  });
+  it('accepts _complete flag', () => {
+    expect(waitlistPatchSchema.safeParse({ _complete: true }).success).toBe(true);
+  });
+  it('rejects email field', () => {
+    expect(waitlistPatchSchema.safeParse({ email: 'a@b.test' }).success).toBe(false);
+  });
+  it('accepts empty patch (heartbeat)', () => {
+    expect(waitlistPatchSchema.safeParse({}).success).toBe(true);
+  });
+});

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+export const USE_CASES = [
+  'one_time_transfer',
+  'business_migration',
+  'scheduled_backup',
+  'private_runner',
+  'browser_runner',
+  'local_backup',
+  'developer',
+  'self_hosted',
+] as const;
+
+export const PROVIDERS = [
+  'google_drive',
+  'onedrive',
+  'dropbox',
+  's3',
+  'sftp',
+  'webdav',
+  'nextcloud',
+  'other',
+] as const;
+
+export const SIZES = ['lt_10gb', '10_to_100gb', '100gb_to_1tb', 'gt_1tb'] as const;
+export const FREQUENCIES = ['one_time', 'weekly', 'daily', 'continuous'] as const;
+export const RUNNERS = ['cloud', 'browser', 'private', 'not_sure'] as const;
+export const ROLES = ['consumer', 'business', 'it', 'developer', 'homelab'] as const;
+export const LOCALES = ['en', 'pt-br'] as const;
+
+export const waitlistPostSchema = z
+  .object({
+    email: z.string().email().max(254),
+    locale: z.enum(LOCALES).default('en'),
+    source_page: z.string().max(255).optional(),
+    segment_hint: z.enum(USE_CASES).nullable().optional(),
+    website: z.string().max(0).optional(),
+  })
+  .strict();
+
+export const waitlistPatchSchema = z
+  .object({
+    use_case: z.enum(USE_CASES).optional(),
+    source_provider: z.enum(PROVIDERS).optional(),
+    dest_provider: z.enum(PROVIDERS).optional(),
+    est_size: z.enum(SIZES).optional(),
+    frequency: z.enum(FREQUENCIES).optional(),
+    preferred_runner: z.enum(RUNNERS).optional(),
+    role: z.enum(ROLES).optional(),
+    _complete: z.boolean().optional(),
+  })
+  .strict();
+
+export type WaitlistPost = z.infer<typeof waitlistPostSchema>;
+export type WaitlistPatch = z.infer<typeof waitlistPatchSchema>;


### PR DESCRIPTION
## Summary
- Adds `src/lib/validation.ts` with `waitlistPostSchema` and `waitlistPatchSchema` (both `.strict()`).
- Exports canonical enum lists: `USE_CASES`, `PROVIDERS`, `SIZES`, `FREQUENCIES`, `RUNNERS`, `ROLES`, `LOCALES`.
- Exports inferred types `WaitlistPost` and `WaitlistPatch`.
- 9 unit tests covering valid/invalid emails, enum membership, unknown-key rejection, and empty heartbeat PATCH.

Closes #14

## Test plan
- [x] `npm test -- --run src/lib/__tests__/validation` — 9 passing
- [x] `npm run lint` — 0 errors