### PR TITLE
feat(dev): internal component showcase page

### DIFF
--- a/src/pages/dev/components.astro
+++ b/src/pages/dev/components.astro
@@ -1,0 +1,168 @@
+---
+import Layout from '../../components/layout/Layout.astro';
+import Section from '../../components/ui/Section.astro';
+import Button from '../../components/ui/Button.astro';
+import Card from '../../components/ui/Card.astro';
+import Input from '../../components/ui/Input.astro';
+import ProviderLogo from '../../components/ui/ProviderLogo.astro';
+
+export const prerender = true;
+
+const providers = [
+  'google-drive',
+  'onedrive',
+  'dropbox',
+  's3',
+  'sftp',
+  'webdav',
+  'nextcloud',
+] as const;
+---
+
+<Layout
+  title="Component Showcase — Syncologic Dev"
+  description="Internal visual smoke test for UI primitives."
+>
+  <Section surface="white" padding="md">
+    <header class="mb-8">
+      <p class="text-caption text-slate-gray">Internal · not linked from production nav</p>
+      <h1 class="text-display-2 text-dark-charcoal">Component showcase</h1>
+      <p class="text-body text-slate-gray mt-2">
+        Every UI primitive in every documented variant. Use this page as a visual smoke test
+        when iterating on tokens or components.
+      </p>
+    </header>
+  </Section>
+
+  <Section surface="soft" padding="md" id="buttons">
+    <h2 class="text-h1 text-dark-charcoal mb-6">Button</h2>
+
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-h3 text-dark-charcoal mb-3">Primary</h3>
+        <div class="flex flex-wrap items-center gap-4">
+          <Button variant="primary" size="sm">Small</Button>
+          <Button variant="primary" size="md">Medium</Button>
+          <Button variant="primary" size="lg">Large</Button>
+          <Button variant="primary" disabled>Disabled</Button>
+          <Button variant="primary" href="#buttons">As link</Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-h3 text-dark-charcoal mb-3">Secondary</h3>
+        <div class="flex flex-wrap items-center gap-4">
+          <Button variant="secondary" size="sm">Small</Button>
+          <Button variant="secondary" size="md">Medium</Button>
+          <Button variant="secondary" size="lg">Large</Button>
+          <Button variant="secondary" disabled>Disabled</Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-h3 text-dark-charcoal mb-3">Ghost</h3>
+        <div class="flex flex-wrap items-center gap-4">
+          <Button variant="ghost" size="sm">Small</Button>
+          <Button variant="ghost" size="md">Medium</Button>
+          <Button variant="ghost" size="lg">Large</Button>
+        </div>
+      </div>
+    </div>
+  </Section>
+
+  <Section surface="white" padding="md" id="cards">
+    <h2 class="text-h1 text-dark-charcoal mb-6">Card</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <Card radius="card" elevation="flat" class="p-6">
+        <h3 class="text-h3 text-dark-charcoal">Flat / card radius</h3>
+        <p class="text-body text-slate-gray mt-2">Default card surface, no shadow.</p>
+      </Card>
+      <Card radius="card" elevation="card" class="p-6">
+        <h3 class="text-h3 text-dark-charcoal">Card elevation</h3>
+        <p class="text-body text-slate-gray mt-2">Subtle interactive lift.</p>
+      </Card>
+      <Card radius="feature" elevation="elevated" class="p-6">
+        <h3 class="text-h3 text-dark-charcoal">Feature / elevated</h3>
+        <p class="text-body text-slate-gray mt-2">24px radius, dropdown-level shadow.</p>
+      </Card>
+    </div>
+  </Section>
+
+  <Section surface="soft" padding="md" id="inputs">
+    <h2 class="text-h1 text-dark-charcoal mb-6">Input</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl">
+      <label class="block">
+        <span class="text-compact text-dark-charcoal">Email</span>
+        <Input type="email" name="demo-email" placeholder="you@example.com" class="mt-2" />
+      </label>
+      <label class="block">
+        <span class="text-compact text-dark-charcoal">Text</span>
+        <Input type="text" name="demo-text" placeholder="Free text" class="mt-2" />
+      </label>
+      <label class="block">
+        <span class="text-compact text-dark-charcoal">Tel</span>
+        <Input type="tel" name="demo-tel" placeholder="+1 555 555 5555" class="mt-2" />
+      </label>
+      <label class="block">
+        <span class="text-compact text-error">Invalid state</span>
+        <Input
+          type="email"
+          name="demo-invalid"
+          value="not-an-email"
+          ariaInvalid={true}
+          class="mt-2"
+        />
+      </label>
+    </div>
+  </Section>
+
+  <Section surface="white" padding="md" id="providers">
+    <h2 class="text-h1 text-dark-charcoal mb-6">ProviderLogo</h2>
+    <div class="space-y-6">
+      <div>
+        <h3 class="text-h3 text-dark-charcoal mb-3">24px</h3>
+        <div class="flex flex-wrap items-center gap-4">
+          {providers.map((p) => <ProviderLogo provider={p} size={24} />)}
+        </div>
+      </div>
+      <div>
+        <h3 class="text-h3 text-dark-charcoal mb-3">48px</h3>
+        <div class="flex flex-wrap items-center gap-6">
+          {providers.map((p) => <ProviderLogo provider={p} size={48} />)}
+        </div>
+      </div>
+    </div>
+  </Section>
+
+  <Section surface="soft" padding="md" id="typography">
+    <h2 class="text-h1 text-dark-charcoal mb-6">Type scale</h2>
+    <div class="space-y-3">
+      <p class="text-display-1 text-dark-charcoal">Display 1 — 64 / 500</p>
+      <p class="text-display-2 text-dark-charcoal">Display 2 — 48 / 500</p>
+      <p class="text-h1 text-dark-charcoal">H1 — 36 / 500</p>
+      <p class="text-h2 text-dark-charcoal">H2 — 28 / 300</p>
+      <p class="text-h3 text-dark-charcoal">H3 — 18 / 700</p>
+      <p class="text-body text-dark-charcoal">Body — 18 / 400. Regular reading copy.</p>
+      <p class="text-compact text-dark-charcoal">Compact — 16 / 500. Nav and UI labels.</p>
+      <p class="text-caption text-slate-gray">Caption — 14 / 400. Metadata.</p>
+      <p class="text-small text-slate-gray">Small — 12 / 400. Footer / legal.</p>
+    </div>
+  </Section>
+
+  <Section surface="dark" padding="md" id="dark-surface">
+    <h2 class="text-h1 text-white mb-6">Dark surface check</h2>
+    <p class="text-body text-white/80 mb-6 max-w-prose">
+      Cards on dark surfaces should rely on border + color separation, not drop shadows.
+    </p>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <Card radius="card" elevation="flat" class="p-6">
+        <h3 class="text-h3 text-dark-charcoal">Default card on dark</h3>
+        <p class="text-body text-slate-gray mt-2">Light card maintains contrast.</p>
+      </Card>
+      <Card radius="feature" elevation="flat" class="p-6">
+        <h3 class="text-h3 text-dark-charcoal">Feature card on dark</h3>
+        <p class="text-body text-slate-gray mt-2">24px radius variant.</p>
+      </Card>
+    </div>
+  </Section>
+</Layout>


### PR DESCRIPTION
## Summary
- Adds `/dev/components` — a single static page rendering every UI primitive (Button, Card, Input, ProviderLogo, Section) in their documented variants, plus the type scale and a dark-surface check.
- Intended as a visual smoke test when iterating on tokens or components. Not linked from production nav.
- No new dependencies. Uses existing primitives + `Layout.astro` only.

No issue exists for this — it's an ad-hoc dev tooling page requested in conversation.

## Verification
- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `npm run build` — clean static build, page emits at `/dev/components` and `/pt-br/dev/components`
- [ ] **Visual verification in a real browser was NOT performed.** Reviewer should run `npm run dev` and eyeball `http://localhost:4321/dev/components` at mobile/tablet/desktop breakpoints before merge.

## Test plan
- [ ] Open `/dev/components` in dev — confirm Button variants render with pill radius and correct hover/active states
- [ ] Confirm Card flat/card/elevated variants are visually distinct
- [ ] Confirm all 7 ProviderLogos render at 24px and 48px
- [ ] Confirm dark-surface section has no shadows on cards
- [ ] Resize to <768px and confirm sections stack cleanly