### PR TITLE
feat(lib): Supabase service-role client + WaitlistRow type (Task 14)

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,36 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.SUPABASE_URL;
+const key = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required');
+}
+
+export const supabase = createClient(url, key, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+export type WaitlistRow = {
+  id: string;
+  email: string;
+  source_page: string | null;
+  segment_hint: string | null;
+  locale: string;
+  use_case: string | null;
+  source_provider: string | null;
+  dest_provider: string | null;
+  est_size: string | null;
+  frequency: string | null;
+  preferred_runner: string | null;
+  role: string | null;
+  user_agent: string | null;
+  referrer: string | null;
+  ip_hash: string | null;
+  unsubscribe_token: string;
+  segmentation_completed_at: string | null;
+  removed_at: string | null;
+  confirmed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
## Summary

- Adds `src/lib/supabase.ts`: typed singleton Supabase client built from server-only `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` with `persistSession: false` and `autoRefreshToken: false`.
- Throws at module load if either env var is missing, so misconfigured deploys fail loud rather than silently use anonymous access.
- Exports a `WaitlistRow` type that mirrors the columns of the `waitlist` migration (`supabase/migrations/20260429000000_waitlist.sql`) for end-to-end strict typing in the upcoming waitlist API endpoints.

Implementation follows the Task 14 spec at `docs/superpowers/plans/2026-04-29-foundation-and-homepage.md` (lines 1371–1425) byte-for-byte. Out of scope per the spec: anon-key client, query helpers, route handlers, browser-facing usage.

## Verification

- [x] `npm run lint` — 0 errors / 0 warnings / 0 hints
- [x] `npm test` — 40 passing
- [x] `npm run build` — clean (`@astrojs/vercel` static output)

## Follow-ups noted in code review (out of scope here)

- `WaitlistRow.locale` and `unsubscribe_token` are typed as non-nullable but the migration columns are nullable; preferred fix is tightening the migration with `not null` rather than relaxing the type. Same for `created_at` / `updated_at` (defaulted but technically nullable).
- Consider passing a `Database` generic to `createClient` once API routes start consuming the client, so `from('waitlist')` returns typed rows instead of `any`.

These are inherited from the plan spec and best handled in a separate task that touches the migration.

## Test Plan

- [x] Type-check passes (`astro check` via `npm run lint`).
- [x] Production build succeeds.
- [x] No client-side bundle picks up the file (consumer endpoints arrive in later tasks; this commit adds no callers).

Closes #17