### PR TITLE
feat(api): GET /api/waitlist/unsubscribe

### DIFF
--- a/src/pages/api/waitlist/unsubscribe.ts
+++ b/src/pages/api/waitlist/unsubscribe.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from 'astro';
+import { supabase } from '../../../lib/supabase';
+
+export const prerender = false;
+
+const UNSUB_PAGE = (locale: 'en' | 'pt-br') => {
+  const en = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>Removed</title>
+    <style>body{font-family:Montserrat,sans-serif;color:#1C2B33;max-width:480px;margin:80px auto;padding:0 24px;line-height:1.5}</style>
+    </head><body><h1 style="font-weight:500">You're removed from the list.</h1>
+    <p>If this was a mistake, just join again from the homepage.</p></body></html>`;
+  const pt = `<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8"/><title>Removido</title>
+    <style>body{font-family:Montserrat,sans-serif;color:#1C2B33;max-width:480px;margin:80px auto;padding:0 24px;line-height:1.5}</style>
+    </head><body><h1 style="font-weight:500">Você foi removido da lista.</h1>
+    <p>Se foi por engano, é só se inscrever de novo na página inicial.</p></body></html>`;
+  return locale === 'pt-br' ? pt : en;
+};
+
+export const GET: APIRoute = async ({ url }) => {
+  const token = url.searchParams.get('token') ?? '';
+  if (token && /^[0-9a-f]{32}$/i.test(token)) {
+    const result = await supabase
+      .from('waitlist')
+      .select('id, locale')
+      .eq('unsubscribe_token', token)
+      .maybeSingle();
+
+    if (result.data) {
+      await supabase
+        .from('waitlist')
+        .update({ removed_at: new Date().toISOString() })
+        .eq('id', result.data.id);
+
+      return new Response(UNSUB_PAGE((result.data.locale as 'en' | 'pt-br') ?? 'en'), {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    }
+  }
+
+  return new Response(UNSUB_PAGE('en'), {
+    status: 200,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
## Summary
- Adds `GET /api/waitlist/unsubscribe` token-gated endpoint
- Validates 32-hex token, sets `removed_at`, returns bilingual (en/pt-BR) confirmation page
- Generic page on bad/missing token to avoid enumeration

Closes #12

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 40 passing
- [x] `npm run build` — clean
- [x] Manual curl against dev server with valid + invalid tokens