### PR TITLE
feat(waitlist): Step 1 email capture form

### DIFF
--- a/src/components/sections/WaitlistForm.astro
+++ b/src/components/sections/WaitlistForm.astro
@@ -34,7 +34,14 @@ const sourcePage = Astro.url.pathname;
         <span class="btn-label-loading hidden">{t('waitlist.submitting')}</span>
       </Button>
     </form>
-    <p class="waitlist-msg mt-3 text-caption text-slate-gray min-h-[20px]" role="status" aria-live="polite"></p>
+    <p
+      class="waitlist-msg mt-3 text-caption text-slate-gray min-h-[20px]"
+      role="status"
+      aria-live="polite"
+      data-msg-success={t('waitlist.success')}
+      data-msg-error-network={t('waitlist.errorNetwork')}
+      data-msg-error-rate={t('waitlist.errorRate')}
+    ></p>
 
     <div class="waitlist-step2 hidden mt-8" data-row-id="" data-token="">
       <!-- Step 2 content rendered by Task 23 -->
@@ -43,21 +50,7 @@ const sourcePage = Astro.url.pathname;
 </section>
 
 <script>
-  type Locale = 'en' | 'pt-br';
   type Stage1Result = { id: string; token: string; status: 'created' | 'existed' };
-
-  const I18N = {
-    en: {
-      success: "✓ You're on the list",
-      errorNetwork: "Couldn't reach the server. Try again?",
-      errorRate: 'Slow down — try again in a minute.',
-    },
-    'pt-br': {
-      success: '✓ Você está na lista',
-      errorNetwork: 'Não consegui falar com o servidor. Tentar de novo?',
-      errorRate: 'Mais devagar — tente daqui a um minuto.',
-    },
-  } as const;
 
   document.querySelectorAll<HTMLFormElement>('.waitlist-form-step1').forEach((form) => {
     const msg = form.parentElement!.querySelector<HTMLElement>('.waitlist-msg')!;
@@ -65,9 +58,14 @@ const sourcePage = Astro.url.pathname;
     const submitBtn = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
     const labelDefault = submitBtn.querySelector<HTMLElement>('.btn-label-default')!;
     const labelLoading = submitBtn.querySelector<HTMLElement>('.btn-label-loading')!;
-    const locale = (form.dataset.locale ?? 'en') as Locale;
+    const locale = form.dataset.locale ?? 'en';
     const sourcePage = form.dataset.sourcePage ?? '/';
     const segmentHint = form.dataset.segmentHint || null;
+    const messages = {
+      success: msg.dataset.msgSuccess ?? '',
+      errorNetwork: msg.dataset.msgErrorNetwork ?? '',
+      errorRate: msg.dataset.msgErrorRate ?? '',
+    };
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -89,16 +87,16 @@ const sourcePage = Astro.url.pathname;
         });
 
         if (res.status === 429) {
-          msg.textContent = I18N[locale].errorRate;
+          msg.textContent = messages.errorRate;
           return;
         }
         if (!res.ok) {
-          msg.textContent = I18N[locale].errorNetwork;
+          msg.textContent = messages.errorNetwork;
           return;
         }
 
         const data = (await res.json()) as Stage1Result;
-        msg.textContent = I18N[locale].success;
+        msg.textContent = messages.success;
         step2.dataset.rowId = data.id;
         step2.dataset.token = data.token;
         step2.classList.remove('hidden');
@@ -107,7 +105,7 @@ const sourcePage = Astro.url.pathname;
           localStorage.setItem(`waitlist:${data.id}`, JSON.stringify({ token: data.token, email }));
         } catch {}
       } catch {
-        msg.textContent = I18N[locale].errorNetwork;
+        msg.textContent = messages.errorNetwork;
       } finally {
         labelDefault.classList.remove('hidden');
         labelLoading.classList.add('hidden');

--- a/src/components/sections/WaitlistForm.astro
+++ b/src/components/sections/WaitlistForm.astro
@@ -1,0 +1,118 @@
+---
+import Button from '../ui/Button.astro';
+import Input from '../ui/Input.astro';
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+import type { WaitlistPost } from '../../lib/validation';
+
+interface Props {
+  segmentHint?: WaitlistPost['segment_hint'];
+  id?: string;
+}
+
+const { segmentHint = null, id = 'waitlist' } = Astro.props;
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const sourcePage = Astro.url.pathname;
+---
+
+<section id={id} data-locale={locale} class="bg-white py-section">
+  <div class="container-wide max-w-2xl text-center">
+    <h2 class="text-h1 font-medium text-dark-charcoal mb-4">{t('nav.joinWaitlist')}</h2>
+    <p class="text-body text-slate-gray mb-8">{t('site.tagline')}</p>
+
+    <form
+      class="waitlist-form-step1 flex flex-col sm:flex-row gap-3 justify-center"
+      data-source-page={sourcePage}
+      data-locale={locale}
+      data-segment-hint={segmentHint}
+      novalidate
+    >
+      <input type="text" name="website" tabindex="-1" autocomplete="off" class="hidden" aria-hidden="true" />
+      <Input type="email" name="email" required placeholder={t('waitlist.emailPlaceholder')} ariaLabel={t('waitlist.emailLabel')} class="sm:max-w-xs" />
+      <Button type="submit" variant="primary">
+        <span class="btn-label-default">{t('waitlist.submit')}</span>
+        <span class="btn-label-loading hidden">{t('waitlist.submitting')}</span>
+      </Button>
+    </form>
+    <p class="waitlist-msg mt-3 text-caption text-slate-gray min-h-[20px]" role="status" aria-live="polite"></p>
+
+    <div class="waitlist-step2 hidden mt-8" data-row-id="" data-token="">
+      <!-- Step 2 content rendered by Task 23 -->
+    </div>
+  </div>
+</section>
+
+<script>
+  type Locale = 'en' | 'pt-br';
+  type Stage1Result = { id: string; token: string; status: 'created' | 'existed' };
+
+  const I18N = {
+    en: {
+      success: "✓ You're on the list",
+      errorNetwork: "Couldn't reach the server. Try again?",
+      errorRate: 'Slow down — try again in a minute.',
+    },
+    'pt-br': {
+      success: '✓ Você está na lista',
+      errorNetwork: 'Não consegui falar com o servidor. Tentar de novo?',
+      errorRate: 'Mais devagar — tente daqui a um minuto.',
+    },
+  } as const;
+
+  document.querySelectorAll<HTMLFormElement>('.waitlist-form-step1').forEach((form) => {
+    const msg = form.parentElement!.querySelector<HTMLElement>('.waitlist-msg')!;
+    const step2 = form.parentElement!.querySelector<HTMLElement>('.waitlist-step2')!;
+    const submitBtn = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
+    const labelDefault = submitBtn.querySelector<HTMLElement>('.btn-label-default')!;
+    const labelLoading = submitBtn.querySelector<HTMLElement>('.btn-label-loading')!;
+    const locale = (form.dataset.locale ?? 'en') as Locale;
+    const sourcePage = form.dataset.sourcePage ?? '/';
+    const segmentHint = form.dataset.segmentHint || null;
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      const email = String(fd.get('email') ?? '').trim();
+      const honeypot = String(fd.get('website') ?? '');
+      if (!email || honeypot) return;
+
+      msg.textContent = '';
+      labelDefault.classList.add('hidden');
+      labelLoading.classList.remove('hidden');
+      submitBtn.disabled = true;
+
+      try {
+        const res = await fetch('/api/waitlist', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ email, locale, source_page: sourcePage, segment_hint: segmentHint }),
+        });
+
+        if (res.status === 429) {
+          msg.textContent = I18N[locale].errorRate;
+          return;
+        }
+        if (!res.ok) {
+          msg.textContent = I18N[locale].errorNetwork;
+          return;
+        }
+
+        const data = (await res.json()) as Stage1Result;
+        msg.textContent = I18N[locale].success;
+        step2.dataset.rowId = data.id;
+        step2.dataset.token = data.token;
+        step2.classList.remove('hidden');
+        form.classList.add('hidden');
+        try {
+          localStorage.setItem(`waitlist:${data.id}`, JSON.stringify({ token: data.token, email }));
+        } catch {}
+      } catch {
+        msg.textContent = I18N[locale].errorNetwork;
+      } finally {
+        labelDefault.classList.remove('hidden');
+        labelLoading.classList.add('hidden');
+        submitBtn.disabled = false;
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary

- Adds `src/components/sections/WaitlistForm.astro` — Step 1 of the inline waitlist (email capture).
- Honeypot field, `<Input>` + `<Button>` primitives, locale-aware status messages via `getT` + `data-*` attributes, optimistic UI revealing the empty `waitlist-step2` placeholder, `localStorage` resume cache.
- Posts to `/api/waitlist` and reads the existing `{id, token, status}` response shape; rate-limit (429) and network failures shown with the corresponding i18n string.

## Notes
- Departure from the plan: the plan kept an inline `I18N` object in the client script. Since `en.json` / `pt-br.json` already have `waitlist.success`, `waitlist.errorNetwork`, and `waitlist.errorRate`, the script now reads them from `data-*` attributes rendered by `getT()` so there is a single source of truth. Functionally identical, no extra runtime cost, and Plan 3 only needs to update the JSON.
- Step 2 is intentionally an empty placeholder (Task 23 / issue #25).
- No homepage assembly here (Task 26 / issue #26) — the form is unmounted for now.

## Verification
- `npm run lint` — 0 errors / 0 warnings.
- `npm test` — 40 / 40 passing.
- `npm run build` — clean production build.
- Visual verification in a real browser was not performed at the targeted breakpoints — the form has no consuming page yet (homepage assembly is a separate task).

Closes #18