### PR TITLE
fix(waitlist): grant table privileges and silence honeypot

### DIFF
--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -16,6 +16,14 @@ describe('waitlistPostSchema', () => {
     const r = waitlistPostSchema.safeParse({ email: 'a@b.test', locale: 'en', evil: 'x' });
     expect(r.success).toBe(false);
   });
+  it('accepts a filled honeypot so the handler can silently 200', () => {
+    const r = waitlistPostSchema.safeParse({
+      email: 'a@b.test',
+      locale: 'en',
+      website: 'http://spam',
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('waitlistPatchSchema', () => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -34,7 +34,7 @@ export const waitlistPostSchema = z
     locale: z.enum(LOCALES).default('en'),
     source_page: z.string().max(255).optional(),
     segment_hint: z.enum(USE_CASES).nullable().optional(),
-    website: z.string().max(0).optional(),
+    website: z.string().optional(),
   })
   .strict();
 

--- a/supabase/migrations/20260429000000_waitlist.sql
+++ b/supabase/migrations/20260429000000_waitlist.sql
@@ -50,3 +50,5 @@ create policy waitlist_insert_anon on waitlist
 drop policy if exists waitlist_service_all on waitlist;
 create policy waitlist_service_all on waitlist
   for all to service_role using (true) with check (true);
+
+grant select, insert, update, delete on waitlist to service_role;


### PR DESCRIPTION
## Summary

Manual end-to-end pass (Task 24, issue #27) ran every step of the waitlist contract against the dev server and Supabase + Resend + Upstash. Two integration bugs surfaced — both invisible to the existing unit tests because they only show up against a real Postgres / real HTTP boundary.

- **Migration was missing `GRANT … TO service_role`.** Postgres evaluates GRANT before RLS, so the existing `for all to service_role` policy was moot and every POST returned `500 server_error` with `permission denied for table waitlist`.
- **Honeypot schema enforced `website` max-length 0.** A bot filling the field got a `400 invalid_input` with `website` named in the response — the exact opposite of a honeypot. The handler in `src/pages/api/waitlist.ts` already had a silent-200 branch for non-empty `website`; relaxing the schema lets that branch run.

## Verification

After applying the table grant in Supabase + the schema fix, all 11 plan steps pass:

| # | Step | Result |
|---|---|---|
| 1 | dev server boots | ✓ |
| 2 | POST happy path | `200 created` |
| 3 | POST idempotency | `200 existed`, same id |
| 4 | PATCH `use_case=business_migration` | `200 ok` |
| 5 | PATCH `use_case=private_runner` (last-write-wins) | `200 ok` |
| 6 | PATCH `_complete=true` | `200 ok` |
| 7 | PATCH after lock | `409 already_completed` |
| 8 | PATCH bad token | `401 invalid_token` |
| 9 | Honeypot filled | `200 ok`, no row created in Supabase |
| 10 | Confirmation email | delivered  ✓ |
| 11 | Commit fix | this PR |

`npm test` (41 passing, includes new honeypot test), `npm run lint` (0/0/0), `npm run build` (clean) all green.

## Notes

- The GRANT was applied to live Supabase via the dashboard SQL editor (single statement: `GRANT SELECT, INSERT, UPDATE, DELETE ON public.waitlist TO service_role;`). The migration file is updated so a fresh apply is correct.
- One footgun discovered along the way: `@vercel/kv` reads `process.env`, not `import.meta.env`, so `npm run dev` doesn't load `.env` for it. Used `node --env-file=.env node_modules/astro/astro.js dev` for the test pass. Worth documenting later, but out of scope here.

Closes #27

## Test plan

- [x] `npm test` (41 passing)
- [x] `npm run lint` (0 errors)
- [x] `npm run build` (clean)
- [x] All 10 curl steps from `docs/superpowers/plans/2026-04-29-foundation-and-homepage.md` Task 24
- [x] Confirmation email delivered to a real inbox