### PR TITLE
feat(sections): ProviderRow, RunnerCards, UseCaseRouter, TrustStory

### DIFF
--- a/src/components/sections/ProviderRow.astro
+++ b/src/components/sections/ProviderRow.astro
@@ -1,0 +1,28 @@
+---
+import ProviderLogo from '../ui/ProviderLogo.astro';
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+
+const providers = [
+  { id: 'google-drive' as const, key: 'googleDrive' },
+  { id: 'onedrive' as const, key: 'oneDrive' },
+  { id: 'dropbox' as const, key: 'dropbox' },
+  { id: 's3' as const, key: 's3' },
+  { id: 'sftp' as const, key: 'sftp' },
+  { id: 'webdav' as const, key: 'webdav' },
+  { id: 'nextcloud' as const, key: 'nextcloud' },
+];
+---
+
+<div class="overflow-x-auto">
+  <ul class="flex items-center gap-8 min-w-max px-4 py-6 justify-center">
+    {providers.map((p) => (
+      <li class="flex items-center gap-2 text-caption text-slate-gray whitespace-nowrap">
+        <ProviderLogo provider={p.id} size={28} />
+        <span>{t(`providers.${p.key}`)}</span>
+      </li>
+    ))}
+  </ul>
+</div>

--- a/src/components/sections/RunnerCards.astro
+++ b/src/components/sections/RunnerCards.astro
@@ -1,0 +1,18 @@
+---
+import Card from '../ui/Card.astro';
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+
+const runners = ['cloud', 'browser', 'private'] as const;
+---
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+  {runners.map((r) => (
+    <Card class="p-8">
+      <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{t(`runners.${r}.name`)}</h3>
+      <p class="text-caption text-slate-gray">{t(`runners.${r}.tagline`)}</p>
+    </Card>
+  ))}
+</div>

--- a/src/components/sections/TrustStory.astro
+++ b/src/components/sections/TrustStory.astro
@@ -1,0 +1,17 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+
+const points = ['preview', 'scoped', 'progress', 'reports', 'transparency'] as const;
+---
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+  {points.map((p) => (
+    <div>
+      <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{t(`trust.${p}.title`)}</h3>
+      <p class="text-caption text-slate-gray leading-relaxed">{t(`trust.${p}.desc`)}</p>
+    </div>
+  ))}
+</div>

--- a/src/components/sections/UseCaseRouter.astro
+++ b/src/components/sections/UseCaseRouter.astro
@@ -1,0 +1,25 @@
+---
+import Card from '../ui/Card.astro';
+import { getLocaleFromUrl, getT, localizedPath } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+
+const useCases = [
+  { slug: 'cloud-to-cloud-transfer', key: 'cloudToCloud' },
+  { slug: 'business-cloud-migration', key: 'businessMigration' },
+  { slug: 'scheduled-cloud-backup', key: 'scheduledBackup' },
+  { slug: 'private-runner', key: 'privateRunner' },
+];
+---
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  {useCases.map((u) => (
+    <a href={localizedPath(locale, `/use-cases/${u.slug}`)} class="block group">
+      <Card class="p-6 transition-transform group-hover:-translate-y-0.5 group-hover:shadow-card">
+        <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{t(`useCaseRouter.${u.key}.title`)}</h3>
+        <p class="text-caption text-slate-gray">{t(`useCaseRouter.${u.key}.desc`)}</p>
+      </Card>
+    </a>
+  ))}
+</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -56,5 +56,45 @@
     "cloud": { "name": "Cloud Runner", "tagline": "Hosted convenience" },
     "browser": { "name": "Browser Runner", "tagline": "Run it in a tab" },
     "private": { "name": "Private Runner", "tagline": "Your machine, your bandwidth" }
+  },
+  "useCaseRouter": {
+    "cloudToCloud": {
+      "title": "Move files between clouds",
+      "desc": "Direct provider-to-provider transfers without local download."
+    },
+    "businessMigration": {
+      "title": "Migrate a team",
+      "desc": "Move a Workspace or Microsoft 365 tenant with reports and previews."
+    },
+    "scheduledBackup": {
+      "title": "Schedule recurring backups",
+      "desc": "Cloud-to-cloud or cloud-to-S3 on a schedule."
+    },
+    "privateRunner": {
+      "title": "Run it on your own machine",
+      "desc": "Keep credentials and bytes on your infrastructure."
+    }
+  },
+  "trust": {
+    "preview": {
+      "title": "Preview before running",
+      "desc": "See exactly what will be added, modified, or skipped — before you commit."
+    },
+    "scoped": {
+      "title": "Scoped access",
+      "desc": "Provider connections request only the permissions the transfer needs."
+    },
+    "progress": {
+      "title": "Live progress",
+      "desc": "File counts, bytes transferred, and estimated time remaining."
+    },
+    "reports": {
+      "title": "Completion reports",
+      "desc": "Per-run audit trail you can share with your team."
+    },
+    "transparency": {
+      "title": "Runner transparency",
+      "desc": "You see and choose where your bytes flow — cloud, browser, or your own machine."
+    }
   }
 }

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -56,5 +56,45 @@
     "cloud": { "name": "Cloud Runner", "tagline": "Hosted convenience" },
     "browser": { "name": "Browser Runner", "tagline": "Run it in a tab" },
     "private": { "name": "Private Runner", "tagline": "Your machine, your bandwidth" }
+  },
+  "useCaseRouter": {
+    "cloudToCloud": {
+      "title": "Move files between clouds",
+      "desc": "Direct provider-to-provider transfers without local download."
+    },
+    "businessMigration": {
+      "title": "Migrate a team",
+      "desc": "Move a Workspace or Microsoft 365 tenant with reports and previews."
+    },
+    "scheduledBackup": {
+      "title": "Schedule recurring backups",
+      "desc": "Cloud-to-cloud or cloud-to-S3 on a schedule."
+    },
+    "privateRunner": {
+      "title": "Run it on your own machine",
+      "desc": "Keep credentials and bytes on your infrastructure."
+    }
+  },
+  "trust": {
+    "preview": {
+      "title": "Preview before running",
+      "desc": "See exactly what will be added, modified, or skipped — before you commit."
+    },
+    "scoped": {
+      "title": "Scoped access",
+      "desc": "Provider connections request only the permissions the transfer needs."
+    },
+    "progress": {
+      "title": "Live progress",
+      "desc": "File counts, bytes transferred, and estimated time remaining."
+    },
+    "reports": {
+      "title": "Completion reports",
+      "desc": "Per-run audit trail you can share with your team."
+    },
+    "transparency": {
+      "title": "Runner transparency",
+      "desc": "You see and choose where your bytes flow — cloud, browser, or your own machine."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds 4 composable marketing sections in `src/components/sections/`: `ProviderRow`, `RunnerCards`, `UseCaseRouter`, `TrustStory`.
- Each follows the plan exactly (`docs/superpowers/plans/2026-04-29-foundation-and-homepage.md` — Task 25).
- `UseCaseRouter` and `TrustStory` strings moved to `useCaseRouter.*` / `trust.*` keys in `en.json` and `pt-br.json` to honor the mandatory-i18n rule (pt-BR mirrors English per Plan 1; Plan 3 replaces with real translations).

## Test plan
- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `npm test` — 41 passing
- [x] `npm run build` — clean static + Vercel adapter build
- [ ] **Visual verification was NOT performed in a real browser at the targeted breakpoints.** These section components have no consumer page yet; they will get a real-browser pass when wired into the homepage in #26.

## Notes
- Reuses existing `<Card>` and `<ProviderLogo>` primitives — no new primitives or tokens.
- No client JS, no new dependencies, no new endpoints.
- Provider order matches `.claude/rules/content.md` canonical list; `other` intentionally excluded from marketing visuals.

Closes #30
Closes #37
Closes #38
Closes #39
Closes #40