### PR TITLE
feat(sections): mobile sticky waitlist bar

### DIFF
--- a/src/components/sections/StickyWaitlistBar.astro
+++ b/src/components/sections/StickyWaitlistBar.astro
@@ -1,0 +1,34 @@
+---
+import Button from '../ui/Button.astro';
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+---
+
+<div
+  id="sticky-waitlist-bar"
+  class="fixed bottom-0 left-0 right-0 z-40 lg:hidden bg-white border-t border-divider px-4 py-3 transform translate-y-full transition-transform duration-300"
+  data-state="hidden"
+>
+  <Button href="#waitlist" variant="primary" class="w-full">{t('nav.joinWaitlist')}</Button>
+</div>
+
+<script>
+  const bar = document.getElementById('sticky-waitlist-bar');
+  if (bar) {
+    const observer = new IntersectionObserver((entries) => {
+      const heroVisible = entries[0]?.isIntersecting;
+      if (heroVisible) {
+        bar.classList.add('translate-y-full');
+        bar.classList.remove('translate-y-0');
+      } else {
+        bar.classList.remove('translate-y-full');
+        bar.classList.add('translate-y-0');
+      }
+    }, { threshold: 0 });
+
+    const hero = document.querySelector<HTMLElement>('[data-hero]');
+    if (hero) observer.observe(hero);
+  }
+</script>


### PR DESCRIPTION
## Summary
- Adds `src/components/sections/StickyWaitlistBar.astro` per Task 27 spec.
- `lg:hidden` fixed bottom bar with a single primary CTA linking to `#waitlist`.
- Uses `IntersectionObserver` on `[data-hero]` to slide in (`translate-y-0`) after the hero leaves the viewport, slide out when hero re-enters.
- Reuses existing `nav.joinWaitlist` i18n key — no new keys.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 41/41 passing
- [x] `npm run build` — clean
- [ ] Manual browser verification at <768px deferred: there is no `[data-hero]` element on the homepage yet (Hero ships in a separate task), so the slide-in transition cannot be exercised in a real browser today. The bar renders hidden as expected; behavior will activate once the hero with `data-hero` lands.

Closes #21