### PR TITLE
feat(use-cases): cloud-to-cloud-transfer landing (en + pt-br)

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,7 +11,6 @@ const ctaSchema = z.object({
 
 const useCaseSchema = z.object({
   locale: localeEnum,
-  slug: z.string(),
   title: z.string().min(8).max(70),
   description: z.string().min(40).max(180),
   ogImage: z.string().optional(),
@@ -27,7 +26,6 @@ const useCaseSchema = z.object({
 
 const guideSchema = z.object({
   locale: localeEnum,
-  slug: z.string(),
   title: z.string().min(8).max(70),
   description: z.string().min(40).max(180),
   ogImage: z.string().optional(),

--- a/src/content/use-cases/en/cloud-to-cloud-transfer.mdx
+++ b/src/content/use-cases/en/cloud-to-cloud-transfer.mdx
@@ -1,0 +1,53 @@
+---
+locale: en
+title: "Cloud-to-cloud file transfer — Syncologic"
+description: "Move folders between Google Drive, OneDrive, Dropbox, S3, and more without pulling everything through your laptop first."
+eyebrow: "For one-time and recurring transfers"
+headline: "Move folders between cloud drives without downloading them first."
+subheading: "Connect a source and destination, preview what will change, run the transfer in the cloud or on your own machine, and get a clear completion report."
+primaryCta:
+  label: "Join the cloud-to-cloud waitlist"
+  href: "#waitlist"
+secondaryCta:
+  label: "See how it works"
+  href: "#how-it-works"
+waitlistSegment: one_time_transfer
+publishedAt: 2026-04-30
+---
+
+## Who this is for
+
+- People switching from one cloud drive to another and tired of dragging gigabytes through a browser tab.
+- Small teams consolidating files across Google Drive, OneDrive, Dropbox, and S3-compatible storage.
+- Anyone who has watched a manual download stall on a folder larger than their laptop's free disk space.
+
+## How it works
+
+1. Connect the source provider — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
+2. Connect the destination provider.
+3. Preview the diff: which files will copy, which already match, and how much will move.
+4. Pick a runner — Cloud Runner for convenience, Browser Runner for a transparent path through your tab, or Private Runner on your own machine.
+5. Run the transfer and download a report when it finishes.
+
+## Why this beats download-and-reupload
+
+A manual download pulls every file through your laptop's disk and your home connection, then pushes the same bytes back up to the new provider. Large folders fail halfway. Browser downloads time out. Drives fill up.
+
+A direct cloud-to-cloud transfer moves the bytes between providers without parking them on your machine. You see what's about to change before it runs, and you get a record of what happened after.
+
+## Three ways to run a transfer
+
+- **Cloud Runner.** Source provider to Syncologic infrastructure to destination provider. Best for convenience and large jobs you don't want to babysit.
+- **Browser Runner.** Source provider to your browser tab to destination provider. The tab stays open while it runs. Best when you want a transparent path with nothing hosted on your behalf.
+- **Private Runner.** Source provider to your own machine, NAS, or VPS to destination provider. Best when bytes and credentials must stay in infrastructure you control.
+
+## Common provider pairs
+
+- Google Drive → OneDrive
+- OneDrive → Google Drive
+- Dropbox → Google Drive
+- Google Drive → Dropbox
+- Google Drive → S3-compatible storage
+- Dropbox → S3-compatible storage
+
+Which two clouds do you want to connect? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/content/use-cases/pt-br/cloud-to-cloud-transfer.mdx
+++ b/src/content/use-cases/pt-br/cloud-to-cloud-transfer.mdx
@@ -1,0 +1,53 @@
+---
+locale: pt-br
+title: "Cloud-to-cloud file transfer — Syncologic"
+description: "Move folders between Google Drive, OneDrive, Dropbox, S3, and more without pulling everything through your laptop first."
+eyebrow: "For one-time and recurring transfers"
+headline: "Move folders between cloud drives without downloading them first."
+subheading: "Connect a source and destination, preview what will change, run the transfer in the cloud or on your own machine, and get a clear completion report."
+primaryCta:
+  label: "Join the cloud-to-cloud waitlist"
+  href: "#waitlist"
+secondaryCta:
+  label: "See how it works"
+  href: "#how-it-works"
+waitlistSegment: one_time_transfer
+publishedAt: 2026-04-30
+---
+
+## Who this is for
+
+- People switching from one cloud drive to another and tired of dragging gigabytes through a browser tab.
+- Small teams consolidating files across Google Drive, OneDrive, Dropbox, and S3-compatible storage.
+- Anyone who has watched a manual download stall on a folder larger than their laptop's free disk space.
+
+## How it works
+
+1. Connect the source provider — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
+2. Connect the destination provider.
+3. Preview the diff: which files will copy, which already match, and how much will move.
+4. Pick a runner — Cloud Runner for convenience, Browser Runner for a transparent path through your tab, or Private Runner on your own machine.
+5. Run the transfer and download a report when it finishes.
+
+## Why this beats download-and-reupload
+
+A manual download pulls every file through your laptop's disk and your home connection, then pushes the same bytes back up to the new provider. Large folders fail halfway. Browser downloads time out. Drives fill up.
+
+A direct cloud-to-cloud transfer moves the bytes between providers without parking them on your machine. You see what's about to change before it runs, and you get a record of what happened after.
+
+## Three ways to run a transfer
+
+- **Cloud Runner.** Source provider to Syncologic infrastructure to destination provider. Best for convenience and large jobs you don't want to babysit.
+- **Browser Runner.** Source provider to your browser tab to destination provider. The tab stays open while it runs. Best when you want a transparent path with nothing hosted on your behalf.
+- **Private Runner.** Source provider to your own machine, NAS, or VPS to destination provider. Best when bytes and credentials must stay in infrastructure you control.
+
+## Common provider pairs
+
+- Google Drive → OneDrive
+- OneDrive → Google Drive
+- Dropbox → Google Drive
+- Google Drive → Dropbox
+- Google Drive → S3-compatible storage
+- Dropbox → S3-compatible storage
+
+Which two clouds do you want to connect? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -10,7 +10,7 @@ import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro
 export async function getStaticPaths() {
   const entries = await getCollection('guides', (e) => e.data.locale === 'en');
   return entries.map((entry) => ({
-    params: { slug: entry.data.slug },
+    params: { slug: entry.slug.replace(/^en\//, '') },
     props: { entry },
   }));
 }

--- a/src/pages/pt-br/guides/[slug].astro
+++ b/src/pages/pt-br/guides/[slug].astro
@@ -10,7 +10,7 @@ import StickyWaitlistBar from '../../../components/sections/StickyWaitlistBar.as
 export async function getStaticPaths() {
   const entries = await getCollection('guides', (e) => e.data.locale === 'pt-br');
   return entries.map((entry) => ({
-    params: { slug: entry.data.slug },
+    params: { slug: entry.slug.replace(/^pt-br\//, '') },
     props: { entry },
   }));
 }

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -10,7 +10,7 @@ import StickyWaitlistBar from '../../../components/sections/StickyWaitlistBar.as
 export async function getStaticPaths() {
   const entries = await getCollection('use-cases', (e) => e.data.locale === 'pt-br');
   return entries.map((entry) => ({
-    params: { slug: entry.data.slug },
+    params: { slug: entry.slug.replace(/^pt-br\//, '') },
     props: { entry },
   }));
 }

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -10,7 +10,7 @@ import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro
 export async function getStaticPaths() {
   const entries = await getCollection('use-cases', (e) => e.data.locale === 'en');
   return entries.map((entry) => ({
-    params: { slug: entry.data.slug },
+    params: { slug: entry.slug.replace(/^en\//, '') },
     props: { entry },
   }));
 }


### PR DESCRIPTION
## Summary

- Adds `/use-cases/cloud-to-cloud-transfer` and `/pt-br/use-cases/cloud-to-cloud-transfer`, the first Plan-2 use-case landing.
- Frontmatter pre-segments the waitlist as `one_time_transfer`; body covers the public, the 5-step workflow, why direct transfer beats download-and-reupload, the three runner options, and common provider pairs.
- pt-br is the standard English-copy placeholder (real translations land in Plan 3).

## Foundation fix

The use-case + guide content schemas declared `slug: z.string()` and the `[slug].astro` templates read `entry.data.slug`. Astro lifts the reserved `slug` frontmatter field out of `data` onto `entry.slug`, so any MDX that satisfied the rest of the schema still failed validation with `slug: Required`. Fixed by:

- removing `slug` from both `useCaseSchema` and `guideSchema`,
- using `entry.slug.replace(/^<locale>\//, '')` in all four `[slug].astro` templates (the slug includes the locale folder).

This unblocks F2–F4 and the guide tasks.

## Verification

- `npx astro check` — 0 errors / 0 warnings.
- `npm test` — 41 passed.
- `npm run build` — clean; both routes generated.
- `npm run dev` — both routes return 200, render the hero (eyebrow / headline / subheading / primary + secondary CTA), all 5 H2 body sections, and a `WaitlistForm` carrying `data-segment-hint=\"one_time_transfer\"`.
- Manual visual at desktop + mobile breakpoints in a real browser was **not** performed in this session — leaving for review on the dev preview.

Closes #80
Refs #79