### PR TITLE
feat: /pricing landing page (en + pt-br)

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -108,6 +108,136 @@
   "faq": {
     "title": "Common questions"
   },
+  "pricing": {
+    "meta": {
+      "title": "Pricing — Syncologic",
+      "description": "Pricing hypotheses for Syncologic. Help us shape the plans before launch — Free, Pro, Business, and Private Runner."
+    },
+    "hero": {
+      "eyebrow": "Pricing",
+      "headline": "Choose the transfer mode that matches your volume, schedule, and trust needs.",
+      "subheading": "We're still shaping pricing. These are working hypotheses, not commitments — join the waitlist and tell us which one fits you.",
+      "primaryCta": "Join the waitlist",
+      "secondaryCta": "See the plan hypotheses"
+    },
+    "hypotheses": {
+      "title": "Four plans we're testing",
+      "subtitle": "Each plan has a hypothesis we want to validate. Tell us which one matches what you'd actually pay for.",
+      "priceSuffix": "/mo",
+      "free": {
+        "name": "Free",
+        "price": "$0",
+        "features": [
+          "Browser Runner only — tab stays open",
+          "One source + destination at a time",
+          "Up to a few GB per transfer"
+        ],
+        "footnote": "What we're testing: whether the Browser Runner alone is useful enough to be a real entry point."
+      },
+      "pro": {
+        "name": "Pro",
+        "price": "~$9",
+        "features": [
+          "Cloud Runner for hands-off transfers",
+          "Scheduled jobs and run reports",
+          "Personal-scale data volumes"
+        ],
+        "footnote": "What we're testing: whether individuals will pay for hosted convenience over manual browser transfers."
+      },
+      "business": {
+        "name": "Business",
+        "price": "~$29",
+        "features": [
+          "Higher data volumes and parallel jobs",
+          "Migration previews and run reports",
+          "Multiple workspace connections"
+        ],
+        "footnote": "What we're testing: whether teams migrating workspaces value the preview, reports, and Cloud Runner enough to pay this tier."
+      },
+      "privateRunner": {
+        "name": "Private Runner",
+        "price": "~$15",
+        "features": [
+          "Run transfers on your own server, NAS, or VPS",
+          "Bytes never touch Syncologic infrastructure",
+          "Pay for the control plane, not for bandwidth"
+        ],
+        "footnote": "What we're testing: whether privacy-minded users will pay a flat fee when they bring their own runner."
+      }
+    },
+    "affects": {
+      "title": "What affects cost",
+      "subtitle": "Three factors shape what your plan should look like.",
+      "volume": {
+        "title": "Data volume",
+        "body": "How much data moves per job and per month — the biggest single driver of bandwidth and storage cost."
+      },
+      "frequency": {
+        "title": "Frequency",
+        "body": "One-time migrations cost differently than recurring backups. Continuous sync sits in its own bucket."
+      },
+      "runner": {
+        "title": "Runner choice",
+        "body": "Cloud Runner uses our bandwidth. Browser and Private Runner don't — so they cost less to operate."
+      }
+    },
+    "cloudVsPrivate": {
+      "title": "Cloud Runner vs Private Runner economics",
+      "subtitle": "Same control plane, different data path. Pick what fits your trust and volume.",
+      "headers": {
+        "dimension": "What changes",
+        "cloud": "Cloud Runner",
+        "private": "Private Runner"
+      },
+      "rows": [
+        {
+          "dimension": "Where the bytes flow",
+          "cloud": "Source → Syncologic infrastructure → destination.",
+          "private": "Source → your machine → destination."
+        },
+        {
+          "dimension": "What you pay for",
+          "cloud": "Hosted bandwidth, scheduling, retries, isolation.",
+          "private": "Control plane only — flat per-month fee."
+        },
+        {
+          "dimension": "Best fit",
+          "cloud": "Convenience, scheduled jobs, migrations you don't want to babysit.",
+          "private": "Privacy, homelabs, businesses, high-volume users on their own bandwidth."
+        }
+      ]
+    },
+    "earlyAccess": {
+      "headline": "Join now and shape the plans.",
+      "body": "We're not charging anyone yet. Waitlist members get early access and a direct say in which hypotheses become real plans.",
+      "cta": "Join the waitlist"
+    },
+    "faq": {
+      "title": "Common pricing questions",
+      "items": [
+        {
+          "q": "Is there really no firm price yet?",
+          "a": "Yes — these numbers are hypotheses we're testing. The waitlist is how we learn which ones map to real demand before we commit."
+        },
+        {
+          "q": "Will the Private Runner cost more than the Cloud Runner?",
+          "a": "Probably less, because you bring the bandwidth. We expect a flat control-plane fee rather than per-GB pricing."
+        },
+        {
+          "q": "What about open-source self-hosting?",
+          "a": "We plan a path toward source-visible, self-hostable infrastructure. Pricing for that path will be set when the model itself is set — see the self-hosted page for details."
+        },
+        {
+          "q": "Will I be charged automatically when launch happens?",
+          "a": "No. Joining the waitlist never bills you. Anyone moving from waitlist to a paid plan does so explicitly."
+        },
+        {
+          "q": "What happens if my use case spans two plans?",
+          "a": "Tell us in the waitlist questions — that signal is exactly what we use to redraw plan boundaries before launch."
+        }
+      ]
+    }
+  },
   "trust": {
     "preview": {
       "title": "See what will happen first",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -108,6 +108,136 @@
   "faq": {
     "title": "Common questions"
   },
+  "pricing": {
+    "meta": {
+      "title": "Pricing — Syncologic",
+      "description": "Pricing hypotheses for Syncologic. Help us shape the plans before launch — Free, Pro, Business, and Private Runner."
+    },
+    "hero": {
+      "eyebrow": "Pricing",
+      "headline": "Choose the transfer mode that matches your volume, schedule, and trust needs.",
+      "subheading": "We're still shaping pricing. These are working hypotheses, not commitments — join the waitlist and tell us which one fits you.",
+      "primaryCta": "Join the waitlist",
+      "secondaryCta": "See the plan hypotheses"
+    },
+    "hypotheses": {
+      "title": "Four plans we're testing",
+      "subtitle": "Each plan has a hypothesis we want to validate. Tell us which one matches what you'd actually pay for.",
+      "priceSuffix": "/mo",
+      "free": {
+        "name": "Free",
+        "price": "$0",
+        "features": [
+          "Browser Runner only — tab stays open",
+          "One source + destination at a time",
+          "Up to a few GB per transfer"
+        ],
+        "footnote": "What we're testing: whether the Browser Runner alone is useful enough to be a real entry point."
+      },
+      "pro": {
+        "name": "Pro",
+        "price": "~$9",
+        "features": [
+          "Cloud Runner for hands-off transfers",
+          "Scheduled jobs and run reports",
+          "Personal-scale data volumes"
+        ],
+        "footnote": "What we're testing: whether individuals will pay for hosted convenience over manual browser transfers."
+      },
+      "business": {
+        "name": "Business",
+        "price": "~$29",
+        "features": [
+          "Higher data volumes and parallel jobs",
+          "Migration previews and run reports",
+          "Multiple workspace connections"
+        ],
+        "footnote": "What we're testing: whether teams migrating workspaces value the preview, reports, and Cloud Runner enough to pay this tier."
+      },
+      "privateRunner": {
+        "name": "Private Runner",
+        "price": "~$15",
+        "features": [
+          "Run transfers on your own server, NAS, or VPS",
+          "Bytes never touch Syncologic infrastructure",
+          "Pay for the control plane, not for bandwidth"
+        ],
+        "footnote": "What we're testing: whether privacy-minded users will pay a flat fee when they bring their own runner."
+      }
+    },
+    "affects": {
+      "title": "What affects cost",
+      "subtitle": "Three factors shape what your plan should look like.",
+      "volume": {
+        "title": "Data volume",
+        "body": "How much data moves per job and per month — the biggest single driver of bandwidth and storage cost."
+      },
+      "frequency": {
+        "title": "Frequency",
+        "body": "One-time migrations cost differently than recurring backups. Continuous sync sits in its own bucket."
+      },
+      "runner": {
+        "title": "Runner choice",
+        "body": "Cloud Runner uses our bandwidth. Browser and Private Runner don't — so they cost less to operate."
+      }
+    },
+    "cloudVsPrivate": {
+      "title": "Cloud Runner vs Private Runner economics",
+      "subtitle": "Same control plane, different data path. Pick what fits your trust and volume.",
+      "headers": {
+        "dimension": "What changes",
+        "cloud": "Cloud Runner",
+        "private": "Private Runner"
+      },
+      "rows": [
+        {
+          "dimension": "Where the bytes flow",
+          "cloud": "Source → Syncologic infrastructure → destination.",
+          "private": "Source → your machine → destination."
+        },
+        {
+          "dimension": "What you pay for",
+          "cloud": "Hosted bandwidth, scheduling, retries, isolation.",
+          "private": "Control plane only — flat per-month fee."
+        },
+        {
+          "dimension": "Best fit",
+          "cloud": "Convenience, scheduled jobs, migrations you don't want to babysit.",
+          "private": "Privacy, homelabs, businesses, high-volume users on their own bandwidth."
+        }
+      ]
+    },
+    "earlyAccess": {
+      "headline": "Join now and shape the plans.",
+      "body": "We're not charging anyone yet. Waitlist members get early access and a direct say in which hypotheses become real plans.",
+      "cta": "Join the waitlist"
+    },
+    "faq": {
+      "title": "Common pricing questions",
+      "items": [
+        {
+          "q": "Is there really no firm price yet?",
+          "a": "Yes — these numbers are hypotheses we're testing. The waitlist is how we learn which ones map to real demand before we commit."
+        },
+        {
+          "q": "Will the Private Runner cost more than the Cloud Runner?",
+          "a": "Probably less, because you bring the bandwidth. We expect a flat control-plane fee rather than per-GB pricing."
+        },
+        {
+          "q": "What about open-source self-hosting?",
+          "a": "We plan a path toward source-visible, self-hostable infrastructure. Pricing for that path will be set when the model itself is set — see the self-hosted page for details."
+        },
+        {
+          "q": "Will I be charged automatically when launch happens?",
+          "a": "No. Joining the waitlist never bills you. Anyone moving from waitlist to a paid plan does so explicitly."
+        },
+        {
+          "q": "What happens if my use case spans two plans?",
+          "a": "Tell us in the waitlist questions — that signal is exactly what we use to redraw plan boundaries before launch."
+        }
+      ]
+    }
+  },
   "trust": {
     "preview": {
       "title": "See what will happen first",

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,0 +1,143 @@
+---
+import { Check } from 'lucide-astro';
+import Layout from '../components/layout/Layout.astro';
+import JsonLd from '../components/layout/JsonLd.astro';
+import Nav from '../components/layout/Nav.astro';
+import Footer from '../components/layout/Footer.astro';
+import Section from '../components/ui/Section.astro';
+import Card from '../components/ui/Card.astro';
+import Button from '../components/ui/Button.astro';
+import Hero from '../components/sections/Hero.astro';
+import FAQ from '../components/sections/FAQ.astro';
+import WaitlistForm from '../components/sections/WaitlistForm.astro';
+import StickyWaitlistBar from '../components/sections/StickyWaitlistBar.astro';
+import { getLocaleFromUrl } from '../i18n/utils';
+import en from '../i18n/en.json';
+import ptBr from '../i18n/pt-br.json';
+
+const locale = getLocaleFromUrl(Astro.url);
+const dict = locale === 'pt-br' ? ptBr : en;
+const p = dict.pricing;
+
+const title = p.meta.title;
+const description = p.meta.description;
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  inLanguage: locale === 'pt-br' ? 'pt-BR' : 'en',
+  mainEntity: p.faq.items.map((item) => ({
+    '@type': 'Question',
+    name: item.q,
+    acceptedAnswer: { '@type': 'Answer', text: item.a },
+  })),
+};
+
+const hypotheses = [
+  p.hypotheses.free,
+  p.hypotheses.pro,
+  p.hypotheses.business,
+  p.hypotheses.privateRunner,
+];
+---
+
+<Layout title={title} description={description}>
+  <JsonLd slot="head" schema={faqSchema} />
+  <Nav slot="nav" />
+
+  <Hero
+    surface="white"
+    eyebrow={p.hero.eyebrow}
+    headline={p.hero.headline}
+    subheading={p.hero.subheading}
+    primaryCta={{ label: p.hero.primaryCta, href: '#waitlist' }}
+    secondaryCta={{ label: p.hero.secondaryCta, href: '#hypotheses' }}
+  />
+
+  <Section surface="soft" padding="lg" id="hypotheses">
+    <div class="text-center mb-12">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{p.hypotheses.title}</h2>
+      <p class="text-body text-slate-gray max-w-xl mx-auto">{p.hypotheses.subtitle}</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      {hypotheses.map((plan) => (
+        <Card radius="card" elevation="flat" class="p-8 flex flex-col gap-5">
+          <div class="flex items-baseline justify-between gap-3">
+            <h3 class="text-h3 font-bold text-dark-charcoal">{plan.name}</h3>
+            <div class="flex items-baseline gap-1">
+              <span class="text-h1 font-medium text-dark-charcoal">{plan.price}</span>
+              <span class="text-caption text-slate-gray">{p.hypotheses.priceSuffix}</span>
+            </div>
+          </div>
+          <ul class="flex flex-col gap-2 text-body text-dark-charcoal list-none p-0">
+            {plan.features.map((feature) => (
+              <li class="flex gap-2 items-start">
+                <Check size={20} strokeWidth={1.5} class="text-slate-gray shrink-0 mt-0.5" aria-hidden="true" />
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+          <p class="text-caption text-slate-gray border-t border-divider pt-4 mt-auto">
+            {plan.footnote}
+          </p>
+        </Card>
+      ))}
+    </div>
+  </Section>
+
+  <Section surface="white" padding="lg">
+    <div class="text-center mb-12">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{p.affects.title}</h2>
+      <p class="text-body text-slate-gray max-w-xl mx-auto">{p.affects.subtitle}</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {[p.affects.volume, p.affects.frequency, p.affects.runner].map((item) => (
+        <div class="flex flex-col gap-2">
+          <h3 class="text-h3 font-bold text-dark-charcoal">{item.title}</h3>
+          <p class="text-body text-slate-gray">{item.body}</p>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <Section surface="soft" padding="lg">
+    <div class="text-center mb-10">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{p.cloudVsPrivate.title}</h2>
+      <p class="text-body text-slate-gray max-w-xl mx-auto">{p.cloudVsPrivate.subtitle}</p>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse text-left bg-white rounded-card overflow-hidden">
+        <thead>
+          <tr class="border-b border-divider">
+            <th class="text-caption font-medium uppercase text-slate-gray px-5 py-4">{p.cloudVsPrivate.headers.dimension}</th>
+            <th class="text-caption font-medium uppercase text-slate-gray px-5 py-4">{p.cloudVsPrivate.headers.cloud}</th>
+            <th class="text-caption font-medium uppercase text-slate-gray px-5 py-4">{p.cloudVsPrivate.headers.private}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {p.cloudVsPrivate.rows.map((row, i) => (
+            <tr class={i < p.cloudVsPrivate.rows.length - 1 ? 'border-b border-divider' : ''}>
+              <td class="text-body text-dark-charcoal font-medium px-5 py-4 align-top">{row.dimension}</td>
+              <td class="text-body text-slate-gray px-5 py-4 align-top">{row.cloud}</td>
+              <td class="text-body text-slate-gray px-5 py-4 align-top">{row.private}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </Section>
+
+  <Section surface="dark" padding="lg">
+    <div class="max-w-2xl mx-auto text-center flex flex-col items-center gap-5">
+      <h2 class="text-h1 font-medium text-white">{p.earlyAccess.headline}</h2>
+      <p class="text-body text-white/80">{p.earlyAccess.body}</p>
+      <Button href="#waitlist" variant="primary" size="lg">{p.earlyAccess.cta}</Button>
+    </div>
+  </Section>
+
+  <WaitlistForm id="waitlist" />
+
+  <FAQ surface="soft" title={p.faq.title} items={p.faq.items} />
+
+  <Footer slot="footer" />
+  <StickyWaitlistBar />
+</Layout>

--- a/src/pages/pt-br/pricing.astro
+++ b/src/pages/pt-br/pricing.astro
@@ -1,0 +1,143 @@
+---
+import { Check } from 'lucide-astro';
+import Layout from '../../components/layout/Layout.astro';
+import JsonLd from '../../components/layout/JsonLd.astro';
+import Nav from '../../components/layout/Nav.astro';
+import Footer from '../../components/layout/Footer.astro';
+import Section from '../../components/ui/Section.astro';
+import Card from '../../components/ui/Card.astro';
+import Button from '../../components/ui/Button.astro';
+import Hero from '../../components/sections/Hero.astro';
+import FAQ from '../../components/sections/FAQ.astro';
+import WaitlistForm from '../../components/sections/WaitlistForm.astro';
+import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro';
+import { getLocaleFromUrl } from '../../i18n/utils';
+import en from '../../i18n/en.json';
+import ptBr from '../../i18n/pt-br.json';
+
+const locale = getLocaleFromUrl(Astro.url);
+const dict = locale === 'pt-br' ? ptBr : en;
+const p = dict.pricing;
+
+const title = p.meta.title;
+const description = p.meta.description;
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  inLanguage: locale === 'pt-br' ? 'pt-BR' : 'en',
+  mainEntity: p.faq.items.map((item) => ({
+    '@type': 'Question',
+    name: item.q,
+    acceptedAnswer: { '@type': 'Answer', text: item.a },
+  })),
+};
+
+const hypotheses = [
+  p.hypotheses.free,
+  p.hypotheses.pro,
+  p.hypotheses.business,
+  p.hypotheses.privateRunner,
+];
+---
+
+<Layout title={title} description={description}>
+  <JsonLd slot="head" schema={faqSchema} />
+  <Nav slot="nav" />
+
+  <Hero
+    surface="white"
+    eyebrow={p.hero.eyebrow}
+    headline={p.hero.headline}
+    subheading={p.hero.subheading}
+    primaryCta={{ label: p.hero.primaryCta, href: '#waitlist' }}
+    secondaryCta={{ label: p.hero.secondaryCta, href: '#hypotheses' }}
+  />
+
+  <Section surface="soft" padding="lg" id="hypotheses">
+    <div class="text-center mb-12">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{p.hypotheses.title}</h2>
+      <p class="text-body text-slate-gray max-w-xl mx-auto">{p.hypotheses.subtitle}</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      {hypotheses.map((plan) => (
+        <Card radius="card" elevation="flat" class="p-8 flex flex-col gap-5">
+          <div class="flex items-baseline justify-between gap-3">
+            <h3 class="text-h3 font-bold text-dark-charcoal">{plan.name}</h3>
+            <div class="flex items-baseline gap-1">
+              <span class="text-h1 font-medium text-dark-charcoal">{plan.price}</span>
+              <span class="text-caption text-slate-gray">{p.hypotheses.priceSuffix}</span>
+            </div>
+          </div>
+          <ul class="flex flex-col gap-2 text-body text-dark-charcoal list-none p-0">
+            {plan.features.map((feature) => (
+              <li class="flex gap-2 items-start">
+                <Check size={20} strokeWidth={1.5} class="text-slate-gray shrink-0 mt-0.5" aria-hidden="true" />
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+          <p class="text-caption text-slate-gray border-t border-divider pt-4 mt-auto">
+            {plan.footnote}
+          </p>
+        </Card>
+      ))}
+    </div>
+  </Section>
+
+  <Section surface="white" padding="lg">
+    <div class="text-center mb-12">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{p.affects.title}</h2>
+      <p class="text-body text-slate-gray max-w-xl mx-auto">{p.affects.subtitle}</p>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {[p.affects.volume, p.affects.frequency, p.affects.runner].map((item) => (
+        <div class="flex flex-col gap-2">
+          <h3 class="text-h3 font-bold text-dark-charcoal">{item.title}</h3>
+          <p class="text-body text-slate-gray">{item.body}</p>
+        </div>
+      ))}
+    </div>
+  </Section>
+
+  <Section surface="soft" padding="lg">
+    <div class="text-center mb-10">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{p.cloudVsPrivate.title}</h2>
+      <p class="text-body text-slate-gray max-w-xl mx-auto">{p.cloudVsPrivate.subtitle}</p>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse text-left bg-white rounded-card overflow-hidden">
+        <thead>
+          <tr class="border-b border-divider">
+            <th class="text-caption font-medium uppercase text-slate-gray px-5 py-4">{p.cloudVsPrivate.headers.dimension}</th>
+            <th class="text-caption font-medium uppercase text-slate-gray px-5 py-4">{p.cloudVsPrivate.headers.cloud}</th>
+            <th class="text-caption font-medium uppercase text-slate-gray px-5 py-4">{p.cloudVsPrivate.headers.private}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {p.cloudVsPrivate.rows.map((row, i) => (
+            <tr class={i < p.cloudVsPrivate.rows.length - 1 ? 'border-b border-divider' : ''}>
+              <td class="text-body text-dark-charcoal font-medium px-5 py-4 align-top">{row.dimension}</td>
+              <td class="text-body text-slate-gray px-5 py-4 align-top">{row.cloud}</td>
+              <td class="text-body text-slate-gray px-5 py-4 align-top">{row.private}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </Section>
+
+  <Section surface="dark" padding="lg">
+    <div class="max-w-2xl mx-auto text-center flex flex-col items-center gap-5">
+      <h2 class="text-h1 font-medium text-white">{p.earlyAccess.headline}</h2>
+      <p class="text-body text-white/80">{p.earlyAccess.body}</p>
+      <Button href="#waitlist" variant="primary" size="lg">{p.earlyAccess.cta}</Button>
+    </div>
+  </Section>
+
+  <WaitlistForm id="waitlist" />
+
+  <FAQ surface="soft" title={p.faq.title} items={p.faq.items} />
+
+  <Footer slot="footer" />
+  <StickyWaitlistBar />
+</Layout>


### PR DESCRIPTION
## Summary

- Adds the `/pricing` and `/pt-br/pricing` landing pages per Task #76 in [the Plan 2 doc](https://github.com/Syncologic/marketing-site/blob/development/docs/superpowers/plans/2026-04-30-audience-landings-and-seo-guides.md).
- Composition (top to bottom): Hero → 4 plan-hypothesis cards (Free / Pro / Business / Private Runner) in a 2×2 grid → "What affects cost" 3-column → Cloud-vs-Private Runner economics table → dark early-access CTA → `WaitlistForm` (`#waitlist`) → FAQ accordion → Footer + `StickyWaitlistBar`.
- New `pricing.*` i18n block in `en.json` and a placeholder mirror in `pt-br.json` (English copy — Plan 3 will translate, per the project rules).
- Locale resolved from URL via `getLocaleFromUrl(Astro.url)` so both files use the shared dictionary lookup pattern.
- FAQ JSON-LD inlined per page with locale-correct `inLanguage`.

## Notes

- Uses existing primitives: `Hero`, `FAQ`, `WaitlistForm`, `Section`, `Card`, `Button`, `StickyWaitlistBar`. No new components.
- Feature-list checkmarks use `lucide-astro`'s `<Check>` (1.5px stroke) per CLAUDE.md icon convention — first usage in the codebase.
- Removed unused `pricing.hypotheses.*.tagline` keys after consolidating each plan card to ≤3 visual hierarchy levels (heading row + body bullets + caption footnote).
- No new dependencies, no new server endpoints.

## Test plan

- [x] `npm run lint` — 0 errors / 0 warnings / 0 hints.
- [x] `npm test` — 41 / 41 passing.
- [x] `npm run build` — clean; `/pricing/index.html` and `/pt-br/pricing/index.html` rendered with all 8 expected content blocks (Hero, hypotheses, affects, comparison table, early-access, waitlist, FAQ, footer) and locale-correct `<link rel="alternate" hreflang>` + FAQ JSON-LD.
- [x] `design-check` (design-reviewer agent) — re-audited and addressed flagged issues: locale detection now via `getLocaleFromUrl`, dark early-access section now has primary `<Button>`, decorative outer `<table>` border removed, `tracking-wide` removed from `<th>`s, lucide `<Check>` replaces inline checkmark SVG, plan cards reduced from 5→3 visual levels.
- [x] **Real-browser visual verification at desktop (1280px) and mobile (375px) — NOT performed.** I built and curl'd the rendered HTML; layout / spacing / responsive grid behavior need a browser pass before merge. Reviewer should run `npm run dev`, hit `/pricing` and `/pt-br/pricing`, and confirm the 2×2 hypothesis grid stacks correctly on mobile and the comparison table scrolls horizontally on narrow viewports.
- [x] Lighthouse mobile Performance ≥ 90 — not run locally; recommend running on the Vercel preview build before merging the eventual deploy PR.

Closes #76