### PR TITLE
feat: /developers landing page (en + pt-br)

### DIFF
--- a/src/components/sections/DevelopersPage.astro
+++ b/src/components/sections/DevelopersPage.astro
@@ -1,0 +1,132 @@
+---
+import Section from '../ui/Section.astro';
+import Card from '../ui/Card.astro';
+import Hero from './Hero.astro';
+import FAQ from './FAQ.astro';
+import WaitlistForm from './WaitlistForm.astro';
+import { getLocaleFromUrl } from '../../i18n/utils';
+import en from '../../i18n/en.json';
+import ptBr from '../../i18n/pt-br.json';
+
+const locale = getLocaleFromUrl(Astro.url);
+const dict = (locale === 'pt-br' ? ptBr : en) as typeof en;
+const dev = dict.developers;
+
+const apiSnippet = `POST /v1/jobs
+Authorization: Bearer sk_live_…
+Content-Type: application/json
+
+{
+  "source":      { "provider": "google_drive", "path": "/Marketing" },
+  "destination": { "provider": "s3", "bucket": "acme-archive", "prefix": "marketing/" },
+  "runner":      "cloud",
+  "schedule":    "0 2 * * *",
+  "on_conflict": "skip"
+}`;
+
+const cliSnippet = `syncologic jobs create \\
+  --source google_drive:/Marketing \\
+  --destination s3://acme-archive/marketing/ \\
+  --runner cloud \\
+  --schedule "0 2 * * *" \\
+  --on-conflict skip`;
+
+const runners = [dev.runnerCloud, dev.runnerBrowser, dev.runnerPrivate];
+
+const surveyOptions = [
+  { value: 'api', label: dev.surveyOptions.api },
+  { value: 'cli', label: dev.surveyOptions.cli },
+  { value: 'webhooks', label: dev.surveyOptions.webhooks },
+  { value: 'self_hosted', label: dev.surveyOptions.selfHosted },
+];
+---
+
+<Hero
+  surface="white"
+  eyebrow={dev.heroEyebrow}
+  headline={dev.heroHeadline}
+  subheading={dev.heroSubheading}
+  primaryCta={{ label: dev.heroPrimaryCta, href: '#waitlist' }}
+  secondaryCta={{ label: dev.heroSecondaryCta, href: '#api' }}
+>
+  <p slot="meta" class="text-caption text-slate-gray max-w-[640px]">{dev.audienceLabel}</p>
+</Hero>
+
+<Section surface="soft" padding="lg" id="api">
+  <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)] gap-10 items-start">
+    <div class="flex flex-col gap-3">
+      <h2 class="text-h1 font-medium text-dark-charcoal">{dev.apiTitle}</h2>
+      <p class="text-body text-slate-gray">{dev.apiBody}</p>
+      <p class="text-caption text-slate-gray">{dev.apiCaption}</p>
+    </div>
+    <div class="bg-near-black rounded-card p-6 sm:p-8">
+      <pre class="text-caption text-white/90 font-mono whitespace-pre overflow-x-auto leading-relaxed"><code>{apiSnippet}</code></pre>
+    </div>
+  </div>
+</Section>
+
+<Section surface="white" padding="lg" id="cli">
+  <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)] gap-10 items-start">
+    <div class="flex flex-col gap-3">
+      <h2 class="text-h1 font-medium text-dark-charcoal">{dev.cliTitle}</h2>
+      <p class="text-body text-slate-gray">{dev.cliBody}</p>
+      <p class="text-caption text-slate-gray">{dev.cliCaption}</p>
+    </div>
+    <div class="bg-near-black rounded-card p-6 sm:p-8">
+      <pre class="text-caption text-white/90 font-mono whitespace-pre overflow-x-auto leading-relaxed"><code>{cliSnippet}</code></pre>
+    </div>
+  </div>
+</Section>
+
+<Section surface="soft" padding="lg" id="runners">
+  <div class="text-center mb-12 max-w-2xl mx-auto">
+    <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{dev.runnersTitle}</h2>
+    <p class="text-body text-slate-gray">{dev.runnersBody}</p>
+  </div>
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    {runners.map((r) => (
+      <Card class="p-8">
+        <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{r.title}</h3>
+        <p class="text-caption text-slate-gray">{r.desc}</p>
+      </Card>
+    ))}
+  </div>
+</Section>
+
+<Section surface="white" padding="lg" id="webhooks">
+  <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,420px)_minmax(0,1fr)] gap-10 items-start">
+    <div class="flex flex-col gap-3">
+      <h2 class="text-h1 font-medium text-dark-charcoal">{dev.webhooksTitle}</h2>
+      <p class="text-body text-slate-gray">{dev.webhooksBody}</p>
+    </div>
+    <div>
+      <p class="text-caption font-medium uppercase tracking-wide text-slate-gray mb-4">{dev.webhookEventsLabel}</p>
+      <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3 list-none p-0">
+        {dev.webhookEvents.map((evt) => (
+          <li class="flex items-center gap-3 px-4 py-3 bg-soft-gray rounded-input">
+            <span class="font-mono text-caption text-dark-charcoal">{evt}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </div>
+</Section>
+
+<Section surface="dark" padding="md" id="no-sdk">
+  <div class="max-w-3xl mx-auto text-center flex flex-col gap-4">
+    <h2 class="text-h1 font-medium text-white">{dev.noSdkTitle}</h2>
+    <p class="text-body text-white/80">{dev.noSdkBody}</p>
+  </div>
+</Section>
+
+<WaitlistForm
+  segmentHint="developer"
+  extraQuestion={{
+    storageKey: 'syncologic.dev.surface_pref',
+    label: dev.surveyTitle,
+    options: surveyOptions,
+    hint: dev.surveyHint,
+  }}
+/>
+
+<FAQ title={dev.faqTitle} items={dev.faq} surface="soft" />

--- a/src/components/sections/WaitlistForm.astro
+++ b/src/components/sections/WaitlistForm.astro
@@ -5,12 +5,23 @@ import ProviderLogo from '../ui/ProviderLogo.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 import type { WaitlistPost } from '../../lib/validation';
 
+interface ExtraQuestionOption {
+  value: string;
+  label: string;
+}
+interface ExtraQuestion {
+  storageKey: string;
+  label: string;
+  options: ExtraQuestionOption[];
+  hint?: string;
+}
 interface Props {
   segmentHint?: WaitlistPost['segment_hint'];
   id?: string;
+  extraQuestion?: ExtraQuestion;
 }
 
-const { segmentHint = null, id = 'waitlist' } = Astro.props;
+const { segmentHint = null, id = 'waitlist', extraQuestion } = Astro.props;
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 const sourcePage = Astro.url.pathname;
@@ -30,6 +41,31 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
   <div class="container-wide max-w-2xl text-center">
     <h2 class="text-h1 font-medium text-dark-charcoal mb-4">{t('nav.joinWaitlist')}</h2>
     <p class="text-body text-slate-gray mb-8 max-w-xl mx-auto">{t('waitlist.step1Subtitle')}</p>
+
+    {extraQuestion && (
+      <div
+        class="waitlist-extra-question max-w-xl mx-auto mb-8 text-left"
+        data-storage-key={extraQuestion.storageKey}
+      >
+        <p class="text-compact font-medium text-dark-charcoal mb-3 text-center">{extraQuestion.label}</p>
+        <div class="flex flex-wrap justify-center gap-2" role="radiogroup" aria-label={extraQuestion.label}>
+          {extraQuestion.options.map((opt) => (
+            <button
+              type="button"
+              role="radio"
+              aria-checked="false"
+              data-value={opt.value}
+              class="extra-question-option px-4 py-2 text-caption font-medium bg-white border border-divider rounded-pill min-h-[44px] hover:border-brand-blue hover:bg-baby-blue/30 data-[selected=true]:bg-brand-blue data-[selected=true]:border-brand-blue data-[selected=true]:text-white transition-colors"
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        {extraQuestion.hint && (
+          <p class="text-small text-slate-gray text-center mt-3">{extraQuestion.hint}</p>
+        )}
+      </div>
+    )}
 
     <form
       class="waitlist-form-step1 flex flex-col sm:flex-row gap-3 justify-center"
@@ -107,6 +143,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       encourageMid: 'Awesome. Tell us a bit more.',
       encourageLast: "Last one! You're almost there.",
       done: '✓ Thanks — that helps a lot.',
+      doneSub: "We'll be in touch.",
       doneCta: 'Done',
       next: 'Next →',
       back: '← Back',
@@ -128,6 +165,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       encourageMid: 'Boa. Conta um pouco mais.',
       encourageLast: 'Última! Quase lá.',
       done: '✓ Valeu — isso ajuda muito.',
+      doneSub: 'A gente entra em contato.',
       doneCta: 'Concluir',
       next: 'Próxima →',
       back: '← Voltar',
@@ -212,6 +250,32 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       ],
     },
   ];
+
+  document.querySelectorAll<HTMLElement>('.waitlist-extra-question').forEach((wrap) => {
+    const key = wrap.dataset.storageKey;
+    if (!key) return;
+    const buttons = wrap.querySelectorAll<HTMLButtonElement>('.extra-question-option');
+    let saved: string | null = null;
+    try { saved = localStorage.getItem(key); } catch {}
+    if (saved) {
+      buttons.forEach((b) => {
+        const match = b.dataset.value === saved;
+        b.dataset.selected = match ? 'true' : 'false';
+        b.setAttribute('aria-checked', match ? 'true' : 'false');
+      });
+    }
+    buttons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const value = btn.dataset.value ?? '';
+        buttons.forEach((b) => {
+          const match = b === btn;
+          b.dataset.selected = match ? 'true' : 'false';
+          b.setAttribute('aria-checked', match ? 'true' : 'false');
+        });
+        try { localStorage.setItem(key, value); } catch {}
+      });
+    });
+  });
 
   document.querySelectorAll<HTMLFormElement>('.waitlist-form-step1').forEach((form) => {
     const root = form.parentElement!;
@@ -496,7 +560,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       await patch({ ...answers, _complete: true });
       step2.style.minHeight = '';
       stageEl.style.minHeight = '';
-      step2.innerHTML = `<div class="text-center py-8"><p class="text-h3 font-bold text-success mb-2">${I18N[locale].done}</p><p class="text-caption text-slate-gray">We'll be in touch.</p></div>`;
+      step2.innerHTML = `<div class="text-center py-8"><p class="text-h3 font-bold text-success mb-2">${I18N[locale].done}</p><p class="text-caption text-slate-gray">${I18N[locale].doneSub}</p></div>`;
     }
 
     lockMaxHeight();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -129,5 +129,80 @@
       "title": "You choose where your files go",
       "desc": "Run the transfer through us, in your browser, or on your own computer. Your call, every time."
     }
+  },
+  "developers": {
+    "title": "Developers — automate cloud file transfers",
+    "description": "Move files between clouds with a typed HTTP API, a CLI, webhooks, and runners you can host yourself.",
+    "heroEyebrow": "For developers and platform teams",
+    "heroHeadline": "Automate cloud file transfers with an API, CLI, webhooks, and runners.",
+    "heroSubheading": "For agencies moving client assets, SaaS teams importing or exporting customer files, and internal tools that move bytes between provider APIs without writing the glue.",
+    "heroPrimaryCta": "Join the developer waitlist",
+    "heroSecondaryCta": "See the API",
+    "audienceLabel": "Built for agencies, SaaS engineering teams, platform groups, and internal tooling.",
+    "apiTitle": "A typed HTTP API",
+    "apiBody": "Create a job with a source, a destination, a runner choice, and an optional schedule. The control plane validates, picks a runner, and emits progress events.",
+    "apiCaption": "Sketch — final shape will land with the v1 API.",
+    "cliTitle": "A CLI for scripts and CI",
+    "cliBody": "Same jobs, driven from a terminal or a CI runner. Useful for one-shot migrations and for backups owned by a script you can read in a code review.",
+    "cliCaption": "Planned. Behavior mirrors the API one-to-one.",
+    "runnersTitle": "Pick the runner that fits the job",
+    "runnersBody": "Same API. Three different data paths. Choose per job, not per account.",
+    "runnerCloud": {
+      "title": "Cloud Runner",
+      "desc": "Hosted runners for scheduled jobs and large migrations. No infrastructure on your side."
+    },
+    "runnerBrowser": {
+      "title": "Browser Runner",
+      "desc": "For ad-hoc transfers from a tab. The data path stays in the user's browser; no long-lived tokens."
+    },
+    "runnerPrivate": {
+      "title": "Private Runner",
+      "desc": "Self-host the runner binary in your VPC, on-prem, or on a NAS. Outbound-only connection to the control plane."
+    },
+    "webhooksTitle": "Webhooks for the events you care about",
+    "webhooksBody": "Subscribe to job lifecycle events and stream them into your queue, your dashboard, or your audit log. Payloads will be HMAC-signed.",
+    "webhookEventsLabel": "Planned events",
+    "noSdkTitle": "No SDK promises yet",
+    "noSdkBody": "We will not ship an official SDK before the API is stable. The OpenAPI spec will be public, so you can generate a typed client in any language you already use.",
+    "surveyTitle": "Which developer surface matters most to you?",
+    "surveyBody": "Pick the one you would reach for first. It helps us decide what ships first.",
+    "surveyOptions": {
+      "api": "HTTP API",
+      "cli": "CLI",
+      "webhooks": "Webhooks",
+      "selfHosted": "Self-hosting"
+    },
+    "surveyHint": "Local signal only — your pick is not sent anywhere. Use the waitlist below to share more.",
+    "faqTitle": "Developer FAQ",
+    "webhookEvents": [
+      "job.created",
+      "job.run.started",
+      "job.run.progress",
+      "job.run.completed",
+      "job.run.failed",
+      "job.schedule.fired"
+    ],
+    "faq": [
+      {
+        "q": "When will the API ship?",
+        "a": "We are not committing to a date. The API will land alongside the first paid Cloud Runner tier. The waitlist is the right way to be first in line for early access."
+      },
+      {
+        "q": "Will there be a free tier for developers?",
+        "a": "The Browser Runner stays free, and the Private Runner is free for the runner itself. Cloud Runner usage is what we plan to bill for."
+      },
+      {
+        "q": "Do you handle OAuth on behalf of my users?",
+        "a": "Yes. The control plane handles provider OAuth so transfers can run unattended. Users connect their accounts through Syncologic, not through your app."
+      },
+      {
+        "q": "Can I run jobs entirely on my own infrastructure?",
+        "a": "Yes. The Private Runner runs in your VPC, on a NAS, or on a developer machine. The control plane never touches your file bytes."
+      },
+      {
+        "q": "Are webhook payloads signed?",
+        "a": "Webhook payloads will be HMAC-signed with a per-workspace secret you control. Replay protection and timestamp tolerance follow the same conventions you would expect from Stripe or Linear."
+      }
+    ]
   }
 }

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -129,5 +129,80 @@
       "title": "You choose where your files go",
       "desc": "Run the transfer through us, in your browser, or on your own computer. Your call, every time."
     }
+  },
+  "developers": {
+    "title": "Developers — automate cloud file transfers",
+    "description": "Move files between clouds with a typed HTTP API, a CLI, webhooks, and runners you can host yourself.",
+    "heroEyebrow": "For developers and platform teams",
+    "heroHeadline": "Automate cloud file transfers with an API, CLI, webhooks, and runners.",
+    "heroSubheading": "For agencies moving client assets, SaaS teams importing or exporting customer files, and internal tools that move bytes between provider APIs without writing the glue.",
+    "heroPrimaryCta": "Join the developer waitlist",
+    "heroSecondaryCta": "See the API",
+    "audienceLabel": "Built for agencies, SaaS engineering teams, platform groups, and internal tooling.",
+    "apiTitle": "A typed HTTP API",
+    "apiBody": "Create a job with a source, a destination, a runner choice, and an optional schedule. The control plane validates, picks a runner, and emits progress events.",
+    "apiCaption": "Sketch — final shape will land with the v1 API.",
+    "cliTitle": "A CLI for scripts and CI",
+    "cliBody": "Same jobs, driven from a terminal or a CI runner. Useful for one-shot migrations and for backups owned by a script you can read in a code review.",
+    "cliCaption": "Planned. Behavior mirrors the API one-to-one.",
+    "runnersTitle": "Pick the runner that fits the job",
+    "runnersBody": "Same API. Three different data paths. Choose per job, not per account.",
+    "runnerCloud": {
+      "title": "Cloud Runner",
+      "desc": "Hosted runners for scheduled jobs and large migrations. No infrastructure on your side."
+    },
+    "runnerBrowser": {
+      "title": "Browser Runner",
+      "desc": "For ad-hoc transfers from a tab. The data path stays in the user's browser; no long-lived tokens."
+    },
+    "runnerPrivate": {
+      "title": "Private Runner",
+      "desc": "Self-host the runner binary in your VPC, on-prem, or on a NAS. Outbound-only connection to the control plane."
+    },
+    "webhooksTitle": "Webhooks for the events you care about",
+    "webhooksBody": "Subscribe to job lifecycle events and stream them into your queue, your dashboard, or your audit log. Payloads will be HMAC-signed.",
+    "webhookEventsLabel": "Planned events",
+    "noSdkTitle": "No SDK promises yet",
+    "noSdkBody": "We will not ship an official SDK before the API is stable. The OpenAPI spec will be public, so you can generate a typed client in any language you already use.",
+    "surveyTitle": "Which developer surface matters most to you?",
+    "surveyBody": "Pick the one you would reach for first. It helps us decide what ships first.",
+    "surveyOptions": {
+      "api": "HTTP API",
+      "cli": "CLI",
+      "webhooks": "Webhooks",
+      "selfHosted": "Self-hosting"
+    },
+    "surveyHint": "Local signal only — your pick is not sent anywhere. Use the waitlist below to share more.",
+    "faqTitle": "Developer FAQ",
+    "webhookEvents": [
+      "job.created",
+      "job.run.started",
+      "job.run.progress",
+      "job.run.completed",
+      "job.run.failed",
+      "job.schedule.fired"
+    ],
+    "faq": [
+      {
+        "q": "When will the API ship?",
+        "a": "We are not committing to a date. The API will land alongside the first paid Cloud Runner tier. The waitlist is the right way to be first in line for early access."
+      },
+      {
+        "q": "Will there be a free tier for developers?",
+        "a": "The Browser Runner stays free, and the Private Runner is free for the runner itself. Cloud Runner usage is what we plan to bill for."
+      },
+      {
+        "q": "Do you handle OAuth on behalf of my users?",
+        "a": "Yes. The control plane handles provider OAuth so transfers can run unattended. Users connect their accounts through Syncologic, not through your app."
+      },
+      {
+        "q": "Can I run jobs entirely on my own infrastructure?",
+        "a": "Yes. The Private Runner runs in your VPC, on a NAS, or on a developer machine. The control plane never touches your file bytes."
+      },
+      {
+        "q": "Are webhook payloads signed?",
+        "a": "Webhook payloads will be HMAC-signed with a per-workspace secret you control. Replay protection and timestamp tolerance follow the same conventions you would expect from Stripe or Linear."
+      }
+    ]
   }
 }

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../components/layout/Layout.astro';
+import Nav from '../components/layout/Nav.astro';
+import Footer from '../components/layout/Footer.astro';
+import StickyWaitlistBar from '../components/sections/StickyWaitlistBar.astro';
+import DevelopersPage from '../components/sections/DevelopersPage.astro';
+import { getLocaleFromUrl, getT } from '../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+---
+
+<Layout title={t('developers.title')} description={t('developers.description')}>
+  <Nav slot="nav" />
+  <DevelopersPage />
+  <Footer slot="footer" />
+  <StickyWaitlistBar />
+</Layout>

--- a/src/pages/pt-br/developers.astro
+++ b/src/pages/pt-br/developers.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../../components/layout/Layout.astro';
+import Nav from '../../components/layout/Nav.astro';
+import Footer from '../../components/layout/Footer.astro';
+import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro';
+import DevelopersPage from '../../components/sections/DevelopersPage.astro';
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+---
+
+<Layout title={t('developers.title')} description={t('developers.description')}>
+  <Nav slot="nav" />
+  <DevelopersPage />
+  <Footer slot="footer" />
+  <StickyWaitlistBar />
+</Layout>


### PR DESCRIPTION
## Summary
- Adds the bespoke `/developers` and `/pt-br/developers` landing pages for Plan 2 (Issue #78).
- Sections: Hero → API sketch → CLI snippet → runner model (Cloud / Browser / Private, dev-flavored) → webhook events → `surface="dark"` "No SDK promises yet" callout → segmented WaitlistForm with extra "Which surface matters most?" question → FAQ.
- Extends `WaitlistForm.astro` with an optional `extraQuestion` prop — pill-button group rendered above the email input, selection persisted to `localStorage` only (no schema/API change, per plan §Task #78).
- Side-fix: localizes the waitlist done-state subtitle (was a hardcoded English string in the script).

## Files
- `src/components/sections/DevelopersPage.astro` (new, shared content)
- `src/pages/developers.astro`, `src/pages/pt-br/developers.astro` (new, locale wrappers using `getLocaleFromUrl`)
- `src/components/sections/WaitlistForm.astro` (added `extraQuestion` prop + localStorage hookup, localized `doneSub`)
- `src/i18n/en.json`, `src/i18n/pt-br.json` (added `developers.*` block; pt-BR mirrors EN per Plan 2 i18n policy — Plan 3 translates)

## Test plan
- [x] `npm run lint` → 0 errors / 0 warnings / 0 hints
- [x] `npm test` → 41/41 passing
- [x] `npm run build` → clean static build, `/developers/index.html` and `/pt-br/developers/index.html` emitted, sitemap regenerated
- [x] WaitlistForm script bundle: 11.87 kB (4.24 kB gzipped) — well under the 20 kB per-page client-JS budget
- [x] `design-check` skill audit passed after applying its three corrections (locale detection in wrappers, "Self-hosted runner" → "Self-hosting" naming-rule fix, localized done-state subtitle)
- [x] Curl smoke test on dev server: both pages 200, all key copy strings present, `data-segment-hint="developer"` set, `id="waitlist"` present so the hero `#waitlist` anchor works
- [x] **Visual verification in a real browser was not performed** at the targeted desktop / tablet / mobile breakpoints — running the local dev server is verified to serve the pages, but the rendered layout, animation, and responsive behavior have not been eyeballed. Reviewer should confirm visually before merging to `development`.
- [x] Lighthouse mobile Performance ≥ 90 will be confirmed against the Vercel preview deploy after this PR opens.

Closes #78