### PR TITLE
feat(guides): SEO guide — transfer Google Drive to OneDrive (#86)

### DIFF
--- a/src/content/guides/en/transfer-google-drive-to-onedrive.mdx
+++ b/src/content/guides/en/transfer-google-drive-to-onedrive.mdx
@@ -1,0 +1,67 @@
+---
+locale: en
+title: "Transfer Google Drive to OneDrive — a practical guide"
+description: "Move folders from Google Drive into OneDrive without dragging every file through your laptop. The honest options for personal accounts, Workspace tenants, and large drives."
+eyebrow: "Guide"
+headline: "Transfer Google Drive to OneDrive"
+subheading: "What still works in 2026, what doesn't, and how to handle large drives or a Workspace-to-Microsoft-365 migration without losing files along the way."
+primaryCta:
+  label: "Join the waitlist"
+  href: "#waitlist"
+waitlistSegment: one_time_transfer
+publishedAt: 2026-05-01
+---
+
+You have files in Google Drive. You want them in OneDrive. Maybe you're switching to Microsoft 365, consolidating a company onto a single workspace, or just tired of paying for two cloud subscriptions. Either way, the path between the two clouds is messier than it should be — and the official tools that used to bridge them are mostly gone.
+
+This guide walks through what still works, where each option breaks, and what to reach for when nothing simple is enough.
+
+## What people usually try first
+
+The default plan is to download every folder from Drive and re-upload it to OneDrive. For a small personal account it's annoying but possible. Past about 50&nbsp;GB it gets unreliable in three ways.
+
+First, **Drive's "Download" splits or stalls on large folders.** The web UI silently breaks very large folders into multiple zip archives, and a long export can fail partway through with no useful error. Native Google file types (Docs, Sheets, Slides) get exported into Office formats automatically — sometimes with subtle formatting drift you only notice weeks later.
+
+Second, **OneDrive's "Upload" doesn't love big batches.** Path-length limits, character restrictions (`#`, `%`, `&`, trailing dots), and the 250&nbsp;GB single-file ceiling all bite during a bulk upload. A dropped Wi-Fi connection mid-job often means restarting from scratch — and Drive's exported zips don't always re-extract cleanly on the other side.
+
+Third, **you lose metadata.** "Last modified" timestamps reset to today. Comments don't translate. Share permissions on Drive have no equivalent in OneDrive's model and are silently dropped. For a personal photo dump that's annoying. For a company migration, "every file is now owned by the person who did the upload" is a real problem.
+
+## What works better
+
+A few approaches sidestep the laptop entirely. Which one fits depends on whether you're moving a personal account or a Workspace tenant.
+
+- **Microsoft Mover.io is gone.** It used to be the obvious answer — Microsoft acquired it in 2019 and ran it as a free Drive→OneDrive bridge. **The service was retired in late 2024**, and is no longer accepting new transfers. If you find a guide telling you to "use Mover," it's out of date.
+- **Microsoft 365's Migration Manager (Workspace → Microsoft 365 only).** If you have a Microsoft 365 Business or Enterprise tenant *and* a Google Workspace tenant, the SharePoint Admin Center's Migration Manager can pull Drive content directly. It preserves more metadata than a manual download. It does not work for personal Gmail/Drive accounts, and it's an admin-only workflow — not something a single user can run for their own files.
+- **Google Takeout, then upload.** Takeout exports Drive into split zip archives. Useful as a backup, painful as a migration: the export is asynchronous (sometimes more than a day), the archive splits don't map cleanly to your folder structure, and you still have to upload everything to OneDrive afterwards. Native Google file types come out as Office files, with the same formatting risk as the manual download path.
+- **`rclone`.** The open-source command-line tool can copy directly between Google Drive and OneDrive without round-tripping through your machine. It's free, transparent, and battle-tested. The cost is configuration — you create OAuth client IDs in both Google Cloud and Azure, write a config file, learn the flag set. For a one-off transfer, that setup time is significant. For repeated migrations, it pays back quickly.
+- **Third-party server-to-server tools.** MultCloud, CloudHQ, and similar services move files between Drive and OneDrive without a local download. They vary widely in pricing, transfer-speed caps, how transparent they are about where your data flows, and whether the free tier is large enough to be useful. Read what each one does before pasting in your OAuth credentials.
+
+For a moderate one-off transfer of a personal account, one of those — usually Takeout or a third-party tool — will get the job done.
+
+## When that still isn't enough
+
+The simple answers cover a lot of cases. They start to break in specific situations:
+
+- **Workspace migrations are different from personal moves.** A company switching from Google Workspace to Microsoft 365 has shared drives, ownership chains, and permission structures that don't survive a download/re-upload round trip. You need a tool that understands "this file is owned by Alice and shared with the marketing team," not just "this file exists at this path."
+- **Large drives push past the limits.** Hundreds of thousands of small files turn into per-file API rate limits, not raw bandwidth, as the bottleneck. A multi-terabyte drive over a residential connection takes days; a flaky connection turns it into weeks of restarts.
+- **Native Google file types don't have OneDrive equivalents.** Docs, Sheets, Slides, Forms — they all need to be exported. The exported `.docx`/`.xlsx`/`.pptx` is *almost* identical, but rare formatting (custom fonts, complex pivot tables, embedded scripts) can drift in ways you won't see until someone opens the file three months later.
+- **You need a manifest.** Audits and migrations end with "show me what was copied, what was skipped, and why." Manual transfers and most consumer tools don't produce one. The migration ends with "I think it's done" — a bad place to be.
+- **Privacy or compliance constraints.** Some teams can't have files traversing a third-party vendor's hosted infrastructure, even briefly. That rules out most of the simple options.
+
+If any of those describe your situation, you're either running `rclone` and writing your own scripts, hiring a migration consultant, or looking for a tool that handles this end-to-end.
+
+## How Syncologic does this
+
+Syncologic is being built for exactly this kind of move — Google Drive to OneDrive (or any other pair of supported clouds) without ever pulling the files through your laptop.
+
+You connect Drive as the source and OneDrive as the destination. You scope access to the folder you actually care about, not your whole drive — relevant if you're moving "Q4 Reports" rather than every file you've ever owned. Before anything moves, you preview the transfer: how many files, total size, name conflicts, items that will be skipped, native Google types that will be exported.
+
+Then you choose where the transfer runs. **Cloud Runner** is the convenient default — Syncologic's infrastructure handles the bytes, with short-lived credentials and isolated job state. **Browser Runner** ("This Device") streams the bytes through your open browser tab; nothing lives on a hosted runner, but the tab has to stay open until it's done. **Private Runner** is a small binary you run yourself on your own machine, NAS, or VPS — bytes flow Drive → your hardware → OneDrive, and Syncologic only sees metadata. For a Workspace-to-Microsoft-365 migration where the data can't leave your control, that's usually the right choice.
+
+Once it starts, you watch progress live. At the end you get a completion report: what copied, what was skipped, what failed and why, with enough detail to act on. The same workflow handles a one-time personal move, a recurring backup, or a full company migration.
+
+## Caveats
+
+A few honest notes. Syncologic is pre-launch — you can join the waitlist below, but you can't run a Drive-to-OneDrive transfer today. Provider coverage starts with seven (Google Drive, OneDrive, Dropbox, S3-compatible storage, SFTP, WebDAV, Nextcloud); Drive and OneDrive are both in. The Browser Runner trades convenience for transparency: it works, but a one-terabyte job over a residential link still takes hours, and the tab has to stay open. And no transfer tool — ours or anyone else's — preserves every piece of provider-specific metadata across vendors. Drive comments and OneDrive's particular sharing model live in the source provider and don't have a clean destination equivalent.
+
+If you're moving a small personal Drive once and don't mind a long upload, Takeout plus a manual reupload will probably get you there. If it's larger, recurring, a Workspace migration, or you need a manifest at the end, drop your email below — we'll let you know when Syncologic is ready.

--- a/src/content/guides/pt-br/transfer-google-drive-to-onedrive.mdx
+++ b/src/content/guides/pt-br/transfer-google-drive-to-onedrive.mdx
@@ -1,0 +1,67 @@
+---
+locale: pt-br
+title: "Transfer Google Drive to OneDrive — a practical guide"
+description: "Move folders from Google Drive into OneDrive without dragging every file through your laptop. The honest options for personal accounts, Workspace tenants, and large drives."
+eyebrow: "Guide"
+headline: "Transfer Google Drive to OneDrive"
+subheading: "What still works in 2026, what doesn't, and how to handle large drives or a Workspace-to-Microsoft-365 migration without losing files along the way."
+primaryCta:
+  label: "Join the waitlist"
+  href: "#waitlist"
+waitlistSegment: one_time_transfer
+publishedAt: 2026-05-01
+---
+
+You have files in Google Drive. You want them in OneDrive. Maybe you're switching to Microsoft 365, consolidating a company onto a single workspace, or just tired of paying for two cloud subscriptions. Either way, the path between the two clouds is messier than it should be — and the official tools that used to bridge them are mostly gone.
+
+This guide walks through what still works, where each option breaks, and what to reach for when nothing simple is enough.
+
+## What people usually try first
+
+The default plan is to download every folder from Drive and re-upload it to OneDrive. For a small personal account it's annoying but possible. Past about 50&nbsp;GB it gets unreliable in three ways.
+
+First, **Drive's "Download" splits or stalls on large folders.** The web UI silently breaks very large folders into multiple zip archives, and a long export can fail partway through with no useful error. Native Google file types (Docs, Sheets, Slides) get exported into Office formats automatically — sometimes with subtle formatting drift you only notice weeks later.
+
+Second, **OneDrive's "Upload" doesn't love big batches.** Path-length limits, character restrictions (`#`, `%`, `&`, trailing dots), and the 250&nbsp;GB single-file ceiling all bite during a bulk upload. A dropped Wi-Fi connection mid-job often means restarting from scratch — and Drive's exported zips don't always re-extract cleanly on the other side.
+
+Third, **you lose metadata.** "Last modified" timestamps reset to today. Comments don't translate. Share permissions on Drive have no equivalent in OneDrive's model and are silently dropped. For a personal photo dump that's annoying. For a company migration, "every file is now owned by the person who did the upload" is a real problem.
+
+## What works better
+
+A few approaches sidestep the laptop entirely. Which one fits depends on whether you're moving a personal account or a Workspace tenant.
+
+- **Microsoft Mover.io is gone.** It used to be the obvious answer — Microsoft acquired it in 2019 and ran it as a free Drive→OneDrive bridge. **The service was retired in late 2024**, and is no longer accepting new transfers. If you find a guide telling you to "use Mover," it's out of date.
+- **Microsoft 365's Migration Manager (Workspace → Microsoft 365 only).** If you have a Microsoft 365 Business or Enterprise tenant *and* a Google Workspace tenant, the SharePoint Admin Center's Migration Manager can pull Drive content directly. It preserves more metadata than a manual download. It does not work for personal Gmail/Drive accounts, and it's an admin-only workflow — not something a single user can run for their own files.
+- **Google Takeout, then upload.** Takeout exports Drive into split zip archives. Useful as a backup, painful as a migration: the export is asynchronous (sometimes more than a day), the archive splits don't map cleanly to your folder structure, and you still have to upload everything to OneDrive afterwards. Native Google file types come out as Office files, with the same formatting risk as the manual download path.
+- **`rclone`.** The open-source command-line tool can copy directly between Google Drive and OneDrive without round-tripping through your machine. It's free, transparent, and battle-tested. The cost is configuration — you create OAuth client IDs in both Google Cloud and Azure, write a config file, learn the flag set. For a one-off transfer, that setup time is significant. For repeated migrations, it pays back quickly.
+- **Third-party server-to-server tools.** MultCloud, CloudHQ, and similar services move files between Drive and OneDrive without a local download. They vary widely in pricing, transfer-speed caps, how transparent they are about where your data flows, and whether the free tier is large enough to be useful. Read what each one does before pasting in your OAuth credentials.
+
+For a moderate one-off transfer of a personal account, one of those — usually Takeout or a third-party tool — will get the job done.
+
+## When that still isn't enough
+
+The simple answers cover a lot of cases. They start to break in specific situations:
+
+- **Workspace migrations are different from personal moves.** A company switching from Google Workspace to Microsoft 365 has shared drives, ownership chains, and permission structures that don't survive a download/re-upload round trip. You need a tool that understands "this file is owned by Alice and shared with the marketing team," not just "this file exists at this path."
+- **Large drives push past the limits.** Hundreds of thousands of small files turn into per-file API rate limits, not raw bandwidth, as the bottleneck. A multi-terabyte drive over a residential connection takes days; a flaky connection turns it into weeks of restarts.
+- **Native Google file types don't have OneDrive equivalents.** Docs, Sheets, Slides, Forms — they all need to be exported. The exported `.docx`/`.xlsx`/`.pptx` is *almost* identical, but rare formatting (custom fonts, complex pivot tables, embedded scripts) can drift in ways you won't see until someone opens the file three months later.
+- **You need a manifest.** Audits and migrations end with "show me what was copied, what was skipped, and why." Manual transfers and most consumer tools don't produce one. The migration ends with "I think it's done" — a bad place to be.
+- **Privacy or compliance constraints.** Some teams can't have files traversing a third-party vendor's hosted infrastructure, even briefly. That rules out most of the simple options.
+
+If any of those describe your situation, you're either running `rclone` and writing your own scripts, hiring a migration consultant, or looking for a tool that handles this end-to-end.
+
+## How Syncologic does this
+
+Syncologic is being built for exactly this kind of move — Google Drive to OneDrive (or any other pair of supported clouds) without ever pulling the files through your laptop.
+
+You connect Drive as the source and OneDrive as the destination. You scope access to the folder you actually care about, not your whole drive — relevant if you're moving "Q4 Reports" rather than every file you've ever owned. Before anything moves, you preview the transfer: how many files, total size, name conflicts, items that will be skipped, native Google types that will be exported.
+
+Then you choose where the transfer runs. **Cloud Runner** is the convenient default — Syncologic's infrastructure handles the bytes, with short-lived credentials and isolated job state. **Browser Runner** ("This Device") streams the bytes through your open browser tab; nothing lives on a hosted runner, but the tab has to stay open until it's done. **Private Runner** is a small binary you run yourself on your own machine, NAS, or VPS — bytes flow Drive → your hardware → OneDrive, and Syncologic only sees metadata. For a Workspace-to-Microsoft-365 migration where the data can't leave your control, that's usually the right choice.
+
+Once it starts, you watch progress live. At the end you get a completion report: what copied, what was skipped, what failed and why, with enough detail to act on. The same workflow handles a one-time personal move, a recurring backup, or a full company migration.
+
+## Caveats
+
+A few honest notes. Syncologic is pre-launch — you can join the waitlist below, but you can't run a Drive-to-OneDrive transfer today. Provider coverage starts with seven (Google Drive, OneDrive, Dropbox, S3-compatible storage, SFTP, WebDAV, Nextcloud); Drive and OneDrive are both in. The Browser Runner trades convenience for transparency: it works, but a one-terabyte job over a residential link still takes hours, and the tab has to stay open. And no transfer tool — ours or anyone else's — preserves every piece of provider-specific metadata across vendors. Drive comments and OneDrive's particular sharing model live in the source provider and don't have a clean destination equivalent.
+
+If you're moving a small personal Drive once and don't mind a long upload, Takeout plus a manual reupload will probably get you there. If it's larger, recurring, a Workspace migration, or you need a manifest at the end, drop your email below — we'll let you know when Syncologic is ready.


### PR DESCRIPTION
## Summary

- Adds the `/guides/transfer-google-drive-to-onedrive` SEO guide MDX in `en` and `pt-br` (English-placeholder per i18n rules; Plan 3 replaces).
- Body follows the guide playbook: *What people usually try first → What works better → When that still isn't enough → How Syncologic does this → Caveats*. Honest about Takeout, `rclone`, M365 Migration Manager, and third-party server-to-server tools before mentioning Syncologic.
- `waitlistSegment: one_time_transfer` so the soft waitlist CTA pre-segments visitors into the cloud-to-cloud segment.
- Body emphasis per the issue: Mover.io was retired in late 2024, Takeout-then-upload is fragile for large drives, Workspace migrations differ from personal moves, and Syncologic offers preview + report + runner choice.

## Test plan

- [x] `npx astro sync` — clean
- [x] `npm run lint` — 0 errors / 0 warnings (52 files)
- [x] `npm run build` — both routes generated:
  - `/guides/transfer-google-drive-to-onedrive/index.html`
  - `/pt-br/guides/transfer-google-drive-to-onedrive/index.html`
- [x] `npm test` — 41/41 pass
- [x] Verified rendered HTML carries `data-segment-hint="one_time_transfer"` on the WaitlistForm
- [x] Visual verification in a real browser at mobile + desktop breakpoints — not performed in this session; recommend the reviewer (or `design-check`) eyeball both routes before merge.

Closes #86
Refs #84