### PR TITLE
feat(use-cases): private-runner landing (en + pt-br)

### DIFF
--- a/src/content/use-cases/en/private-runner.mdx
+++ b/src/content/use-cases/en/private-runner.mdx
@@ -1,0 +1,89 @@
+---
+locale: en
+title: "Private Runner — transfer files on your own infrastructure"
+description: "Run cloud-to-cloud transfers through your own machine, server, NAS, or VPS. Bytes and credentials stay in infrastructure you control."
+eyebrow: "For privacy, homelabs, and businesses with sensitive data"
+headline: "Run transfers on your own machine, server, NAS, or VPS."
+subheading: "Use Syncologic to coordinate the job and a Private Runner you control to move the bytes. Credentials and file contents never touch our infrastructure."
+primaryCta:
+  label: "Join the Private Runner waitlist"
+  href: "#waitlist"
+secondaryCta:
+  label: "See how it works"
+  href: "#how-it-works"
+waitlistSegment: private_runner
+publishedAt: 2026-05-01
+---
+
+## Who this is for
+
+- Privacy-conscious users who want a hosted control plane but not a hosted data plane.
+- Small businesses with sensitive data — legal archives, financial records, regulated content — that shouldn't pass through anyone else's infrastructure.
+- Homelab operators with an always-on server, NAS, or VPS already built for jobs like this.
+- High-volume users who'd rather pay for software and bring their own bandwidth than rent throughput.
+
+## The data path
+
+The Cloud Runner sends bytes through Syncologic infrastructure. The Private Runner doesn't.
+
+```
+Source provider  →  Your Private Runner  →  Destination provider
+```
+
+Files flow directly from the source API to the runner you operate, then on to the destination. Our control plane sees what the job is, when it ran, and a structured report at the end. It never sees the file contents and never holds the long-lived credentials.
+
+## Outbound connection only
+
+You don't open a port. The runner makes an outbound connection to the control plane and waits for work. When a job is dispatched, it pulls a short-lived run lease, runs the transfer, and posts progress events back.
+
+That means:
+
+- No inbound firewall rules.
+- No public IP requirement.
+- No reverse proxy or tunnel.
+- Works behind home NAT, behind a corporate proxy, behind anything that allows outbound HTTPS.
+
+## How it works
+
+1. Install the runner on a machine you control — a NAS, a VPS, a Linux box, a workstation, a Raspberry Pi that stays on.
+2. Pair it with your Syncologic account using a one-time enrolment code.
+3. Connect your source and destination providers from the control plane like normal.
+4. When you dispatch a job, pick the Private Runner instead of the Cloud Runner.
+5. The runner pulls the work, transfers the files between provider APIs, and reports back when it's done.
+
+## Where you'd run it
+
+The runner is small enough to live next to other lightweight services on hardware you already own.
+
+- A Synology, QNAP, or TrueNAS box that's already on 24/7.
+- A homelab Linux server or mini-PC running other long-lived jobs.
+- A small VPS — Hetzner, Fly, DigitalOcean, OVH — for users who want it off-prem but still under their account.
+- A workstation that's reliably online during business hours, for one-time migrations.
+- A Raspberry Pi class device for slower, low-throughput backups.
+
+The runner cares about reliable network and enough disk for staging buffers; it doesn't care which distro or hardware you picked.
+
+## Credential handling
+
+OAuth tokens for your providers are bound to the runner. They're encrypted at rest using a key derived from your enrolment, and they don't leave the machine. Our control plane sees provider identifiers, scopes, and run metadata — never refresh tokens, never file contents.
+
+If you decommission the runner, revoke the enrolment from the control plane and the tokens it held become useless.
+
+## Cloud Runner vs Private Runner
+
+| | Cloud Runner | Private Runner |
+|---|---|---|
+| Where bytes flow | Source → Syncologic infra → destination | Source → your machine → destination |
+| Where credentials live | Encrypted in our infra, short-lived | On your runner, never leaves |
+| Setup effort | None — pick it from the dropdown | Install + pair once |
+| Best for | Convenience, very large jobs | Privacy, sensitive data, homelabs, high volume |
+| Pricing model | Usage-based on our infra | Pay for software; you bring bandwidth |
+| Network requirements | None | Outbound HTTPS from the runner |
+
+Both runners use the same control plane, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow.
+
+## Public source and a future self-host path
+
+The runner is being built so it can run today against our hosted control plane and later against a self-hosted one. The core code is source-visible — you can read what it does before you install it. Self-hosting the control plane is a separate, longer track; the Private Runner is the first step on that path.
+
+Where would you run your Private Runner — NAS, homelab server, VPS, or workstation? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/content/use-cases/en/private-runner.mdx
+++ b/src/content/use-cases/en/private-runner.mdx
@@ -26,9 +26,7 @@ publishedAt: 2026-05-01
 
 The Cloud Runner sends bytes through Syncologic infrastructure. The Private Runner doesn't.
 
-```
-Source provider  →  Your Private Runner  →  Destination provider
-```
+`Source provider` → `Your Private Runner` → `Destination provider`
 
 Files flow directly from the source API to the runner you operate, then on to the destination. Our control plane sees what the job is, when it ran, and a structured report at the end. It never sees the file contents and never holds the long-lived credentials.
 
@@ -71,14 +69,23 @@ If you decommission the runner, revoke the enrolment from the control plane and 
 
 ## Cloud Runner vs Private Runner
 
-| | Cloud Runner | Private Runner |
-|---|---|---|
-| Where bytes flow | Source → Syncologic infra → destination | Source → your machine → destination |
-| Where credentials live | Encrypted in our infra, short-lived | On your runner, never leaves |
-| Setup effort | None — pick it from the dropdown | Install + pair once |
-| Best for | Convenience, very large jobs | Privacy, sensitive data, homelabs, high volume |
-| Pricing model | Usage-based on our infra | Pay for software; you bring bandwidth |
-| Network requirements | None | Outbound HTTPS from the runner |
+### Cloud Runner
+
+- **Where bytes flow:** source → Syncologic infrastructure → destination.
+- **Where credentials live:** encrypted in our infrastructure, short-lived.
+- **Setup effort:** none — pick it from the dropdown.
+- **Best for:** convenience, very large jobs you don't want to host yourself.
+- **Pricing model:** usage-based on our infrastructure.
+- **Network requirements:** none.
+
+### Private Runner
+
+- **Where bytes flow:** source → your machine → destination.
+- **Where credentials live:** on your runner, never leaves.
+- **Setup effort:** install and pair once.
+- **Best for:** privacy, sensitive data, homelabs, high-volume users.
+- **Pricing model:** pay for software; you bring bandwidth.
+- **Network requirements:** outbound HTTPS from the runner.
 
 Both runners use the same control plane, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow.
 

--- a/src/content/use-cases/pt-br/private-runner.mdx
+++ b/src/content/use-cases/pt-br/private-runner.mdx
@@ -26,9 +26,7 @@ publishedAt: 2026-05-01
 
 The Cloud Runner sends bytes through Syncologic infrastructure. The Private Runner doesn't.
 
-```
-Source provider  →  Your Private Runner  →  Destination provider
-```
+`Source provider` → `Your Private Runner` → `Destination provider`
 
 Files flow directly from the source API to the runner you operate, then on to the destination. Our control plane sees what the job is, when it ran, and a structured report at the end. It never sees the file contents and never holds the long-lived credentials.
 
@@ -71,14 +69,23 @@ If you decommission the runner, revoke the enrolment from the control plane and 
 
 ## Cloud Runner vs Private Runner
 
-| | Cloud Runner | Private Runner |
-|---|---|---|
-| Where bytes flow | Source → Syncologic infra → destination | Source → your machine → destination |
-| Where credentials live | Encrypted in our infra, short-lived | On your runner, never leaves |
-| Setup effort | None — pick it from the dropdown | Install + pair once |
-| Best for | Convenience, very large jobs | Privacy, sensitive data, homelabs, high volume |
-| Pricing model | Usage-based on our infra | Pay for software; you bring bandwidth |
-| Network requirements | None | Outbound HTTPS from the runner |
+### Cloud Runner
+
+- **Where bytes flow:** source → Syncologic infrastructure → destination.
+- **Where credentials live:** encrypted in our infrastructure, short-lived.
+- **Setup effort:** none — pick it from the dropdown.
+- **Best for:** convenience, very large jobs you don't want to host yourself.
+- **Pricing model:** usage-based on our infrastructure.
+- **Network requirements:** none.
+
+### Private Runner
+
+- **Where bytes flow:** source → your machine → destination.
+- **Where credentials live:** on your runner, never leaves.
+- **Setup effort:** install and pair once.
+- **Best for:** privacy, sensitive data, homelabs, high-volume users.
+- **Pricing model:** pay for software; you bring bandwidth.
+- **Network requirements:** outbound HTTPS from the runner.
 
 Both runners use the same control plane, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow.
 

--- a/src/content/use-cases/pt-br/private-runner.mdx
+++ b/src/content/use-cases/pt-br/private-runner.mdx
@@ -1,0 +1,89 @@
+---
+locale: pt-br
+title: "Private Runner — transfer files on your own infrastructure"
+description: "Run cloud-to-cloud transfers through your own machine, server, NAS, or VPS. Bytes and credentials stay in infrastructure you control."
+eyebrow: "For privacy, homelabs, and businesses with sensitive data"
+headline: "Run transfers on your own machine, server, NAS, or VPS."
+subheading: "Use Syncologic to coordinate the job and a Private Runner you control to move the bytes. Credentials and file contents never touch our infrastructure."
+primaryCta:
+  label: "Join the Private Runner waitlist"
+  href: "#waitlist"
+secondaryCta:
+  label: "See how it works"
+  href: "#how-it-works"
+waitlistSegment: private_runner
+publishedAt: 2026-05-01
+---
+
+## Who this is for
+
+- Privacy-conscious users who want a hosted control plane but not a hosted data plane.
+- Small businesses with sensitive data — legal archives, financial records, regulated content — that shouldn't pass through anyone else's infrastructure.
+- Homelab operators with an always-on server, NAS, or VPS already built for jobs like this.
+- High-volume users who'd rather pay for software and bring their own bandwidth than rent throughput.
+
+## The data path
+
+The Cloud Runner sends bytes through Syncologic infrastructure. The Private Runner doesn't.
+
+```
+Source provider  →  Your Private Runner  →  Destination provider
+```
+
+Files flow directly from the source API to the runner you operate, then on to the destination. Our control plane sees what the job is, when it ran, and a structured report at the end. It never sees the file contents and never holds the long-lived credentials.
+
+## Outbound connection only
+
+You don't open a port. The runner makes an outbound connection to the control plane and waits for work. When a job is dispatched, it pulls a short-lived run lease, runs the transfer, and posts progress events back.
+
+That means:
+
+- No inbound firewall rules.
+- No public IP requirement.
+- No reverse proxy or tunnel.
+- Works behind home NAT, behind a corporate proxy, behind anything that allows outbound HTTPS.
+
+## How it works
+
+1. Install the runner on a machine you control — a NAS, a VPS, a Linux box, a workstation, a Raspberry Pi that stays on.
+2. Pair it with your Syncologic account using a one-time enrolment code.
+3. Connect your source and destination providers from the control plane like normal.
+4. When you dispatch a job, pick the Private Runner instead of the Cloud Runner.
+5. The runner pulls the work, transfers the files between provider APIs, and reports back when it's done.
+
+## Where you'd run it
+
+The runner is small enough to live next to other lightweight services on hardware you already own.
+
+- A Synology, QNAP, or TrueNAS box that's already on 24/7.
+- A homelab Linux server or mini-PC running other long-lived jobs.
+- A small VPS — Hetzner, Fly, DigitalOcean, OVH — for users who want it off-prem but still under their account.
+- A workstation that's reliably online during business hours, for one-time migrations.
+- A Raspberry Pi class device for slower, low-throughput backups.
+
+The runner cares about reliable network and enough disk for staging buffers; it doesn't care which distro or hardware you picked.
+
+## Credential handling
+
+OAuth tokens for your providers are bound to the runner. They're encrypted at rest using a key derived from your enrolment, and they don't leave the machine. Our control plane sees provider identifiers, scopes, and run metadata — never refresh tokens, never file contents.
+
+If you decommission the runner, revoke the enrolment from the control plane and the tokens it held become useless.
+
+## Cloud Runner vs Private Runner
+
+| | Cloud Runner | Private Runner |
+|---|---|---|
+| Where bytes flow | Source → Syncologic infra → destination | Source → your machine → destination |
+| Where credentials live | Encrypted in our infra, short-lived | On your runner, never leaves |
+| Setup effort | None — pick it from the dropdown | Install + pair once |
+| Best for | Convenience, very large jobs | Privacy, sensitive data, homelabs, high volume |
+| Pricing model | Usage-based on our infra | Pay for software; you bring bandwidth |
+| Network requirements | None | Outbound HTTPS from the runner |
+
+Both runners use the same control plane, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow.
+
+## Public source and a future self-host path
+
+The runner is being built so it can run today against our hosted control plane and later against a self-hosted one. The core code is source-visible — you can read what it does before you install it. Self-hosting the control plane is a separate, longer track; the Private Runner is the first step on that path.
+
+Where would you run your Private Runner — NAS, homelab server, VPS, or workstation? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -81,6 +81,34 @@
   .prose-syncologic code {
     @apply bg-soft-gray rounded-input px-1.5 py-0.5 text-caption;
   }
+  .prose-syncologic table {
+    @apply w-full my-6 text-body border-collapse;
+  }
+  .prose-syncologic thead {
+    @apply border-b border-divider;
+  }
+  .prose-syncologic th {
+    @apply text-left font-medium text-dark-charcoal py-3 pr-4 align-top;
+  }
+  .prose-syncologic td {
+    @apply py-3 pr-4 align-top border-b border-divider;
+  }
+  .prose-syncologic tr:last-child td {
+    @apply border-b-0;
+  }
+  @media (max-width: 767px) {
+    .prose-syncologic table {
+      display: block;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      max-width: 100%;
+    }
+    .prose-syncologic th,
+    .prose-syncologic td {
+      min-width: 11rem;
+      white-space: normal;
+    }
+  }
   .prose-syncologic > :first-child {
     margin-top: 0;
   }


### PR DESCRIPTION
## Summary
- Adds `/use-cases/private-runner` MDX in both locales (pt-br ships English placeholder copy per Plan 2 i18n rules).
- Body emphasises the data path (source → user's runner → destination), outbound-only connection model, NAS / VPS examples, credential handling, and a Cloud Runner vs Private Runner comparison table.
- Frontmatter pre-segments waitlist signups as `private_runner`; final segmentation question asks where the runner would run.
- User-facing copy uses "Private Runner" throughout (per `.claude/rules/content.md` naming rule).

## Test plan
- [x] `npx astro sync && npx astro check` — 0 errors, 0 warnings.
- [x] `npm run build` — clean; both `/use-cases/private-runner/` and `/pt-br/use-cases/private-runner/` rendered into `dist/`.
- [x] `npm test` — 41 tests pass.
- [ ] Visual verification at desktop + mobile breakpoints **was not performed** in a real browser.

Closes #83
Refs #79