### PR TITLE
chore(content): trim and reframe non-homepage copy

### DIFF
--- a/src/components/sections/DevelopersPage.astro
+++ b/src/components/sections/DevelopersPage.astro
@@ -32,13 +32,6 @@ const cliSnippet = `syncologic jobs create \\
   --on-conflict skip`;
 
 const runners = [dev.runnerCloud, dev.runnerBrowser, dev.runnerPrivate];
-
-const surveyOptions = [
-  { value: 'api', label: dev.surveyOptions.api },
-  { value: 'cli', label: dev.surveyOptions.cli },
-  { value: 'webhooks', label: dev.surveyOptions.webhooks },
-  { value: 'self_hosted', label: dev.surveyOptions.selfHosted },
-];
 ---
 
 <Hero
@@ -119,14 +112,6 @@ const surveyOptions = [
   </div>
 </Section>
 
-<WaitlistForm
-  segmentHint="developer"
-  extraQuestion={{
-    storageKey: 'syncologic.dev.surface_pref',
-    label: dev.surveyTitle,
-    options: surveyOptions,
-    hint: dev.surveyHint,
-  }}
-/>
+<WaitlistForm segmentHint="developer" />
 
 <FAQ title={dev.faqTitle} items={dev.faq} surface="soft" />

--- a/src/components/sections/FAQ.astro
+++ b/src/components/sections/FAQ.astro
@@ -4,6 +4,10 @@ import Section from '../ui/Section.astro';
 interface FaqItem {
   q: string;
   a: string;
+  link?: {
+    href: string;
+    label: string;
+  };
 }
 
 interface Props {
@@ -40,6 +44,17 @@ const { title, items, surface = 'soft', id } = Astro.props;
             </summary>
             <div class="px-6 pb-5 -mt-1 text-body text-slate-gray">
               {item.a}
+              {item.link && (
+                <>
+                  {' '}
+                  <a
+                    href={item.link.href}
+                    class="text-brand-blue hover:underline focus-visible:underline"
+                  >
+                    {item.link.label} →
+                  </a>
+                </>
+              )}
             </div>
           </details>
         </li>

--- a/src/components/sections/SelfHostedSections.astro
+++ b/src/components/sections/SelfHostedSections.astro
@@ -113,8 +113,5 @@ const futureLevels = ['level1', 'level2', 'level3'] as const;
     <p class="text-body text-white/80">
       {t('selfHosted.sourceTrust.body')}
     </p>
-    <p class="text-body text-white/80">
-      {t('selfHosted.sourceTrust.body2')}
-    </p>
   </div>
 </Section>

--- a/src/components/sections/WaitlistForm.astro
+++ b/src/components/sections/WaitlistForm.astro
@@ -5,23 +5,12 @@ import ProviderLogo from '../ui/ProviderLogo.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 import type { WaitlistPost } from '../../lib/validation';
 
-interface ExtraQuestionOption {
-  value: string;
-  label: string;
-}
-interface ExtraQuestion {
-  storageKey: string;
-  label: string;
-  options: ExtraQuestionOption[];
-  hint?: string;
-}
 interface Props {
   segmentHint?: WaitlistPost['segment_hint'];
   id?: string;
-  extraQuestion?: ExtraQuestion;
 }
 
-const { segmentHint = null, id = 'waitlist', extraQuestion } = Astro.props;
+const { segmentHint = null, id = 'waitlist' } = Astro.props;
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 const sourcePage = Astro.url.pathname;
@@ -41,31 +30,6 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
   <div class="container-wide max-w-2xl text-center">
     <h2 class="text-h1 font-medium text-dark-charcoal mb-4">{t('nav.joinWaitlist')}</h2>
     <p class="text-body text-slate-gray mb-8 max-w-xl mx-auto">{t('waitlist.step1Subtitle')}</p>
-
-    {extraQuestion && (
-      <div
-        class="waitlist-extra-question max-w-xl mx-auto mb-8 text-left"
-        data-storage-key={extraQuestion.storageKey}
-      >
-        <p class="text-compact font-medium text-dark-charcoal mb-3 text-center">{extraQuestion.label}</p>
-        <div class="flex flex-wrap justify-center gap-2" role="radiogroup" aria-label={extraQuestion.label}>
-          {extraQuestion.options.map((opt) => (
-            <button
-              type="button"
-              role="radio"
-              aria-checked="false"
-              data-value={opt.value}
-              class="extra-question-option px-4 py-2 text-caption font-medium bg-white border border-divider rounded-pill min-h-[44px] hover:border-brand-blue hover:bg-baby-blue/30 data-[selected=true]:bg-brand-blue data-[selected=true]:border-brand-blue data-[selected=true]:text-white transition-colors"
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
-        {extraQuestion.hint && (
-          <p class="text-small text-slate-gray text-center mt-3">{extraQuestion.hint}</p>
-        )}
-      </div>
-    )}
 
     <form
       class="waitlist-form-step1 flex flex-col sm:flex-row gap-3 justify-center"
@@ -250,32 +214,6 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       ],
     },
   ];
-
-  document.querySelectorAll<HTMLElement>('.waitlist-extra-question').forEach((wrap) => {
-    const key = wrap.dataset.storageKey;
-    if (!key) return;
-    const buttons = wrap.querySelectorAll<HTMLButtonElement>('.extra-question-option');
-    let saved: string | null = null;
-    try { saved = localStorage.getItem(key); } catch {}
-    if (saved) {
-      buttons.forEach((b) => {
-        const match = b.dataset.value === saved;
-        b.dataset.selected = match ? 'true' : 'false';
-        b.setAttribute('aria-checked', match ? 'true' : 'false');
-      });
-    }
-    buttons.forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const value = btn.dataset.value ?? '';
-        buttons.forEach((b) => {
-          const match = b === btn;
-          b.dataset.selected = match ? 'true' : 'false';
-          b.setAttribute('aria-checked', match ? 'true' : 'false');
-        });
-        try { localStorage.setItem(key, value); } catch {}
-      });
-    });
-  });
 
   document.querySelectorAll<HTMLFormElement>('.waitlist-form-step1').forEach((form) => {
     const root = form.parentElement!;

--- a/src/content/guides/en/move-files-between-clouds-without-downloading.mdx
+++ b/src/content/guides/en/move-files-between-clouds-without-downloading.mdx
@@ -48,13 +48,13 @@ If any of those describe your situation, a CLI plus a cron job can still work �
 
 ## How Syncologic does this
 
-Syncologic moves files between clouds without ever pulling them through your laptop. The workflow is the same regardless of provider pair:
+Syncologic will move files between clouds without ever pulling them through your laptop. The workflow is the same regardless of provider pair:
 
 You connect a source and a destination — Google Drive, OneDrive, Dropbox, S3-compatible storage, SFTP, WebDAV, or Nextcloud. You scope access to the folder you actually care about, not the whole drive. You preview what will be transferred before anything moves: count, total size, conflicts, files that will be skipped. Then you choose where the transfer runs.
 
-There are three options for that. **Cloud Runner** is the convenient default — Syncologic infrastructure does the work, with short-lived credentials and isolated job state. **Browser Runner** ("This Device") streams the bytes through your open browser tab, so nothing lives on a hosted runner; the trade-off is that the tab must stay open. **Private Runner** is a small binary you run yourself, on your own machine, NAS, or VPS — the bytes flow source → your hardware → destination, and Syncologic only sees metadata.
+There are three options for that. **Cloud Runner** is the convenient default — Syncologic infrastructure does the work, with short-lived credentials and isolated job state. **Browser Runner** ("This Device") streams the bytes through your open browser tab, so nothing lives on a hosted runner; the trade-off is that the tab will need to stay open. **Private Runner** is a small binary you run yourself, on your own machine, NAS, or VPS — the bytes flow source → your hardware → destination, and Syncologic only sees metadata.
 
-Once it's running, you watch progress live and get a completion report at the end: what copied, what was skipped, what failed and why. The same workflow handles a one-time migration, a scheduled backup, or a cross-cloud sync.
+Once it's running, you'll watch progress live and get a completion report at the end: what copied, what was skipped, what failed and why. The same workflow will handle a one-time migration, a scheduled backup, or a cross-cloud sync.
 
 ## Caveats
 

--- a/src/content/guides/en/transfer-google-drive-to-onedrive.mdx
+++ b/src/content/guides/en/transfer-google-drive-to-onedrive.mdx
@@ -56,9 +56,9 @@ Syncologic is being built for exactly this kind of move — Google Drive to OneD
 
 You connect Drive as the source and OneDrive as the destination. You scope access to the folder you actually care about, not your whole drive — relevant if you're moving "Q4 Reports" rather than every file you've ever owned. Before anything moves, you preview the transfer: how many files, total size, name conflicts, items that will be skipped, native Google types that will be exported.
 
-Then you choose where the transfer runs. **Cloud Runner** is the convenient default — Syncologic's infrastructure handles the bytes, with short-lived credentials and isolated job state. **Browser Runner** ("This Device") streams the bytes through your open browser tab; nothing lives on a hosted runner, but the tab has to stay open until it's done. **Private Runner** is a small binary you run yourself on your own machine, NAS, or VPS — bytes flow Drive → your hardware → OneDrive, and Syncologic only sees metadata. For a Workspace-to-Microsoft-365 migration where the data can't leave your control, that's usually the right choice.
+Then you choose where the transfer runs. **Cloud Runner** is the convenient default — Syncologic's infrastructure handles the bytes, with short-lived credentials and isolated job state. **Browser Runner** ("This Device") streams the bytes through your open browser tab; nothing lives on a hosted runner, but the tab will need to stay open until it's done. **Private Runner** is a small binary you run yourself on your own machine, NAS, or VPS — bytes flow Drive → your hardware → OneDrive, and Syncologic only sees metadata. For a Workspace-to-Microsoft-365 migration where the data can't leave your control, that's usually the right choice.
 
-Once it starts, you watch progress live. At the end you get a completion report: what copied, what was skipped, what failed and why, with enough detail to act on. The same workflow handles a one-time personal move, a recurring backup, or a full company migration.
+Once it starts, you'll watch progress live. At the end you'll get a completion report: what copied, what was skipped, what failed and why, with enough detail to act on. The same workflow will handle a one-time personal move, a recurring backup, or a full company migration.
 
 ## Caveats
 

--- a/src/content/use-cases/en/business-cloud-migration.mdx
+++ b/src/content/use-cases/en/business-cloud-migration.mdx
@@ -3,14 +3,14 @@ locale: en
 title: "Business cloud migration — Syncologic"
 description: "Move team files to a new cloud workspace with a preview, progress tracking, and a final report — without dragging gigabytes through a laptop."
 eyebrow: "For founders, ops leads, and IT generalists"
-headline: "Move your team to a new cloud workspace with a preview and a final report."
-subheading: "Connect the source workspace and the destination, preview what will change, run the transfer in the cloud or on your own machine, and hand over a report when it's done."
+headline: "Move your team to a new cloud workspace."
+subheading: "Workspace-to-workspace migration with previews, progress tracking, and a final report."
 primaryCta:
   label: "Join the business migration waitlist"
   href: "#waitlist"
 secondaryCta:
-  label: "See how it works"
-  href: "#how-it-works"
+  label: "See how it'll work"
+  href: "#how-itll-work"
 waitlistSegment: business_migration
 publishedAt: 2026-05-01
 ---
@@ -27,7 +27,7 @@ A personal move can tolerate a missed file. A business move can't. Stakeholders 
 
 Manual workspace migrations turn into missing files, duplicated folders, and quiet permission drift. The fix isn't more spreadsheets — it's visibility built into the transfer.
 
-## How it works
+## How it'll work
 
 1. Connect the source workspace — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
 2. Connect the destination workspace.
@@ -37,11 +37,11 @@ Manual workspace migrations turn into missing files, duplicated folders, and qui
 
 ## Preview before you commit
 
-Every job starts with a dry-run. You see the file count, the total size, the folders involved, and the conflicts before a single byte moves. Stakeholders can sign off on the preview instead of trusting a verbal estimate.
+Every job will start with a dry-run — file count, total size, folders involved, conflicts. Stakeholders can sign off on the preview instead of trusting a verbal estimate.
 
 ## A report at the end
 
-When a run finishes, you get a structured report — what copied, what was skipped, what failed and why. Keep it for the audit trail. Re-run only the failed items if anything needs a second pass.
+When a run finishes, you'll get a structured report — what copied, what was skipped, what failed and why. Keep it for the audit trail. Re-run only the failed items if anything needs a second pass.
 
 ## Schedule the cutover
 
@@ -49,7 +49,7 @@ Plan migrations in stages instead of one weekend marathon. Schedule a job for of
 
 ## Private Runner for sensitive moves
 
-Some data shouldn't pass through anyone else's infrastructure — legal archives, financial records, regulated content. Run those jobs through a Private Runner on your own server, NAS, or VPS. The control plane still coordinates the work; the bytes never leave your network.
+Some data shouldn't pass through anyone else's infrastructure — legal archives, financial records, regulated content. Run those through a Private Runner on your own server, NAS, or VPS. Bytes stay on your network; the control plane only coordinates.
 
 ## Common workspace pairs
 

--- a/src/content/use-cases/en/cloud-to-cloud-transfer.mdx
+++ b/src/content/use-cases/en/cloud-to-cloud-transfer.mdx
@@ -4,13 +4,13 @@ title: "Cloud-to-cloud file transfer — Syncologic"
 description: "Move folders between Google Drive, OneDrive, Dropbox, S3, and more without pulling everything through your laptop first."
 eyebrow: "For one-time and recurring transfers"
 headline: "Move folders between cloud drives without downloading them first."
-subheading: "Connect a source and destination, preview what will change, run the transfer in the cloud or on your own machine, and get a clear completion report."
+subheading: "Direct cloud-to-cloud folder transfer with previews and reports."
 primaryCta:
   label: "Join the cloud-to-cloud waitlist"
   href: "#waitlist"
 secondaryCta:
-  label: "See how it works"
-  href: "#how-it-works"
+  label: "See how it'll work"
+  href: "#how-itll-work"
 waitlistSegment: one_time_transfer
 publishedAt: 2026-04-30
 ---
@@ -21,7 +21,7 @@ publishedAt: 2026-04-30
 - Small teams consolidating files across Google Drive, OneDrive, Dropbox, and S3-compatible storage.
 - Anyone who has watched a manual download stall on a folder larger than their laptop's free disk space.
 
-## How it works
+## How it'll work
 
 1. Connect the source provider — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
 2. Connect the destination provider.
@@ -31,14 +31,14 @@ publishedAt: 2026-04-30
 
 ## Why this beats download-and-reupload
 
-A manual download pulls every file through your laptop's disk and your home connection, then pushes the same bytes back up to the new provider. Large folders fail halfway. Browser downloads time out. Drives fill up.
+Manual transfers pull every file through your laptop, then push the same bytes back up. Large folders fail halfway. Browser downloads time out. Drives fill up.
 
-A direct cloud-to-cloud transfer moves the bytes between providers without parking them on your machine. You see what's about to change before it runs, and you get a record of what happened after.
+A direct cloud-to-cloud transfer moves the bytes between providers without parking them on your machine. You'll see what's about to change before it runs, and get a report when it's done.
 
-## Three ways to run a transfer
+## Three ways to run a transfer at launch
 
 - **Cloud Runner.** Source provider to Syncologic infrastructure to destination provider. Best for convenience and large jobs you don't want to babysit.
-- **Browser Runner.** Source provider to your browser tab to destination provider. The tab stays open while it runs. Best when you want a transparent path with nothing hosted on your behalf.
+- **Browser Runner.** Source provider to your browser tab to destination provider. The tab will need to stay open while it runs. Best when you want a transparent path with nothing hosted on your behalf.
 - **Private Runner.** Source provider to your own machine, NAS, or VPS to destination provider. Best when bytes and credentials must stay in infrastructure you control.
 
 ## Common provider pairs

--- a/src/content/use-cases/en/private-runner.mdx
+++ b/src/content/use-cases/en/private-runner.mdx
@@ -4,13 +4,13 @@ title: "Private Runner — transfer files on your own infrastructure"
 description: "Run cloud-to-cloud transfers through your own machine, server, NAS, or VPS. Bytes and credentials stay in infrastructure you control."
 eyebrow: "For privacy, homelabs, and businesses with sensitive data"
 headline: "Run transfers on your own machine, server, NAS, or VPS."
-subheading: "Use Syncologic to coordinate the job and a Private Runner you control to move the bytes. Credentials and file contents never touch our infrastructure."
+subheading: "Hosted control plane, your data path. Bytes and credentials stay on infrastructure you control."
 primaryCta:
   label: "Join the Private Runner waitlist"
   href: "#waitlist"
 secondaryCta:
-  label: "See how it works"
-  href: "#how-it-works"
+  label: "See how it'll work"
+  href: "#how-itll-work"
 waitlistSegment: private_runner
 publishedAt: 2026-05-01
 ---
@@ -28,7 +28,7 @@ The Cloud Runner sends bytes through Syncologic infrastructure. The Private Runn
 
 `Source provider` → `Your Private Runner` → `Destination provider`
 
-Files flow directly from the source API to the runner you operate, then on to the destination. Our control plane sees what the job is, when it ran, and a structured report at the end. It never sees the file contents and never holds the long-lived credentials.
+Files flow directly from the source API to the runner you operate, then to the destination. The control plane sees what the job is and when it ran — never the file contents, never long-lived credentials.
 
 ## Outbound connection only
 
@@ -41,7 +41,7 @@ That means:
 - No reverse proxy or tunnel.
 - Works behind home NAT, behind a corporate proxy, behind anything that allows outbound HTTPS.
 
-## How it works
+## How it'll work
 
 1. Install the runner on a machine you control — a NAS, a VPS, a Linux box, a workstation, a Raspberry Pi that stays on.
 2. Pair it with your Syncologic account using a one-time enrolment code.
@@ -63,9 +63,9 @@ The runner cares about reliable network and enough disk for staging buffers; it 
 
 ## Credential handling
 
-OAuth tokens for your providers are bound to the runner. They're encrypted at rest using a key derived from your enrolment, and they don't leave the machine. Our control plane sees provider identifiers, scopes, and run metadata — never refresh tokens, never file contents.
+Provider OAuth tokens will be bound to the runner — encrypted at rest with a key derived from your enrolment, never leaving the machine. The control plane sees provider identifiers, scopes, and run metadata; never refresh tokens, never file contents.
 
-If you decommission the runner, revoke the enrolment from the control plane and the tokens it held become useless.
+Decommission the runner and revoke its enrolment from the control plane — the tokens it held will become useless.
 
 ## Cloud Runner vs Private Runner
 
@@ -91,6 +91,6 @@ Both runners use the same control plane, the same job definitions, the same prev
 
 ## Public source and a future self-host path
 
-The runner is being built so it can run today against our hosted control plane and later against a self-hosted one. The core code is source-visible — you can read what it does before you install it. Self-hosting the control plane is a separate, longer track; the Private Runner is the first step on that path.
+The runner will work against our hosted control plane at launch, and against a self-hosted control plane later. The core code will ship source-visible — you can audit it before installing. Self-host of the control plane is a separate, longer track; Private Runner is the first step.
 
 Where would you run your Private Runner — NAS, homelab server, VPS, or workstation? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/content/use-cases/en/scheduled-cloud-backup.mdx
+++ b/src/content/use-cases/en/scheduled-cloud-backup.mdx
@@ -3,14 +3,14 @@ locale: en
 title: "Scheduled cloud backup — Syncologic"
 description: "Back up important cloud folders to S3 or another destination on a schedule, with change detection and a report at the end of every run."
 eyebrow: "For users and small teams who want recurring backups"
-headline: "Back up important cloud folders on a schedule — without babysitting manual exports."
-subheading: "Connect a source and a destination, set a schedule, and let each run copy only what changed. Get a clear report when it finishes."
+headline: "Back up cloud folders on a schedule."
+subheading: "Scheduled cloud backups with change detection and a report after every run."
 primaryCta:
   label: "Join the backup waitlist"
   href: "#waitlist"
 secondaryCta:
-  label: "See how it works"
-  href: "#how-it-works"
+  label: "See how it'll work"
+  href: "#how-itll-work"
 waitlistSegment: scheduled_backup
 publishedAt: 2026-05-01
 ---
@@ -27,7 +27,7 @@ A single cloud drive holds the live copy. Sync isn't backup — a deletion, a ra
 
 Manual exports work once. They don't survive a busy quarter. The folder you forgot to export is the one you'll wish you had.
 
-## How it works
+## How it'll work
 
 1. Connect the source — Google Drive, OneDrive, Dropbox, Nextcloud, or another provider.
 2. Connect the destination — S3-compatible storage is the common choice, but Drive, Dropbox, and others are supported.
@@ -37,19 +37,19 @@ Manual exports work once. They don't survive a busy quarter. The folder you forg
 
 ## Scheduled jobs that actually run
 
-Set a schedule once and the job runs on its own. Daily snapshots of a working folder. A weekly copy of an entire workspace. A continuous mirror of a critical project. The schedule keeps the backup current; you stop being the cron job.
+Set a schedule once and the job will run on its own — daily snapshots, weekly workspace copies, a continuous mirror of a critical project. The schedule keeps the backup current; you stop being the cron job.
 
 ## Change detection between runs
 
-Each run compares the source against the last successful backup and copies only what's new or changed. The first run moves everything. Every run after that moves a fraction of it — fast, predictable, and cheap to store.
+Each run will compare the source against the last successful backup and copy only what's new or changed. The first run moves everything. Every run after that moves a fraction of it — fast, predictable, and cheap to store.
 
 ## A report after every run
 
-When a run finishes you get a structured report: what copied, what was skipped, what failed. Keep it as the audit trail. If something failed, re-run only the failed items instead of redoing the whole job.
+When a run finishes you'll get a structured report: what copied, what was skipped, what failed. Keep it as the audit trail. If something failed, re-run only the failed items instead of redoing the whole job.
 
 ## Destination options
 
-S3-compatible storage is the most common backup destination — durable, cheap at rest, and decoupled from your working provider. The same scheduled job can also write to a second cloud drive (Drive → Dropbox, OneDrive → Drive) or to a Nextcloud or WebDAV target you control.
+S3-compatible storage is the most common backup destination — durable, cheap at rest, decoupled from your working provider. The same job can also write to a second cloud drive or a Nextcloud / WebDAV target you control.
 
 Common pairs we expect to see:
 
@@ -61,6 +61,6 @@ Common pairs we expect to see:
 
 ## Pricing signal
 
-Backups are about volume, frequency, and retention — not seats. Pricing will reflect that. Expect a free tier for small recurring jobs, paid tiers as data and frequency grow, and a Private Runner option when you'd rather pay for software and bring your own bandwidth and destination.
+Backups are about volume, frequency, and retention — not seats. See pricing for the plan ladder.
 
 How often would you want backups to run? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -342,9 +342,9 @@
     },
     "hero": {
       "eyebrow": "Self-hosted future",
-      "headline": "Source-visible. Self-hostable. On your timeline.",
-      "subheading": "Syncologic is being designed with a path toward source-visible, self-hostable infrastructure. Here's what's available now, and what we're planning.",
-      "audience": "For technical buyers, homelab operators, and businesses that want an exit path from hosted SaaS.",
+      "headline": "Source-visible. Self-hostable. Yours to run.",
+      "subheading": "Source-visible runner at launch. Self-hostable control plane on the roadmap.",
+      "audience": "For homelab operators, privacy-conscious users, and businesses that want their file transfers running on infrastructure they control.",
       "primaryCta": "Join the self-hosting waitlist",
       "secondaryCta": "See the principles"
     },
@@ -353,17 +353,17 @@
       "intro": "We separate the metadata layer from where files actually move. That split is what makes self-hosting tractable.",
       "controlPlane": {
         "title": "Control plane",
-        "desc": "Auth, jobs, schedules, reports. The metadata layer — what you'd self-host first."
+        "desc": "Accounts, jobs, schedules, reports. The metadata layer — hosted by us at launch, self-hostable on the roadmap."
       },
       "dataPlane": {
         "title": "Data plane",
-        "desc": "Where bytes flow. Source → runner → destination. Never through us by default."
+        "desc": "Where bytes flow. Source → runner → destination. Self-host the runner from launch; bytes never reach the control plane."
       },
       "note": "Files do not flow through our server. The server holds metadata; the runner moves the bytes."
     },
     "privateRunner": {
-      "title": "Private Runner: the first concrete step",
-      "body": "Before any full self-host story, you can plan to run transfers on your own infrastructure. Connect your machine, NAS, or VPS to our control plane — credentials and bytes stay with you.",
+      "title": "Private Runner: available first",
+      "body": "Run transfers on your own machine, NAS, or VPS at launch. Your provider credentials and file bytes stay with you; the control plane only holds job metadata.",
       "outbound": {
         "title": "Outbound only",
         "desc": "Your runner reaches out to us. No inbound ports, no exposed services."
@@ -379,8 +379,8 @@
     },
     "futureModel": {
       "title": "Future self-host levels",
-      "label": "Planned, not committed",
-      "intro": "Three levels we're planning, in increasing order of independence from our infrastructure.",
+      "label": "On the roadmap",
+      "intro": "Three levels of self-hosting, in increasing independence from our infrastructure.",
       "level1": {
         "name": "Private Runner",
         "status": "Available first",
@@ -399,8 +399,7 @@
     },
     "sourceTrust": {
       "title": "Why core code stays public",
-      "body": "Runner code, transfer logic, and provider adapters are source-visible. You can audit how files move before trusting the system.",
-      "body2": "Private repos exist only for ops runbooks, security incidents, and business material — never for product code."
+      "body": "Runner code, transfer logic, and provider adapters will ship source-visible. You'll be able to audit how files move before trusting the system."
     }
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -111,18 +111,18 @@
   "pricing": {
     "meta": {
       "title": "Pricing — Syncologic",
-      "description": "Pricing hypotheses for Syncologic. Help us shape the plans before launch — Free, Pro, Business, and Private Runner."
+      "description": "Plans for how you transfer — Free, Pro, Business, and Private Runner. Join the waitlist for early access."
     },
     "hero": {
       "eyebrow": "Pricing",
-      "headline": "Choose the transfer mode that matches your volume, schedule, and trust needs.",
-      "subheading": "We're still shaping pricing. These are working hypotheses, not commitments — join the waitlist and tell us which one fits you.",
+      "headline": "Pick the plan that matches how you transfer.",
+      "subheading": "Four plans, four ways our users transfer. Pick yours and join the waitlist for early access.",
       "primaryCta": "Join the waitlist",
-      "secondaryCta": "See the plan hypotheses"
+      "secondaryCta": "See the plans"
     },
     "hypotheses": {
-      "title": "Four plans we're testing",
-      "subtitle": "Each plan has a hypothesis we want to validate. Tell us which one matches what you'd actually pay for.",
+      "title": "Four plans",
+      "subtitle": "Each plan maps to a clear use case. Pick the one that fits you.",
       "priceSuffix": "/mo",
       "free": {
         "name": "Free",
@@ -132,7 +132,7 @@
           "One source + destination at a time",
           "Up to a few GB per transfer"
         ],
-        "footnote": "What we're testing: whether the Browser Runner alone is useful enough to be a real entry point."
+        "footnote": "For one-off transfers and trying Syncologic before paying."
       },
       "pro": {
         "name": "Pro",
@@ -142,7 +142,7 @@
           "Scheduled jobs and run reports",
           "Personal-scale data volumes"
         ],
-        "footnote": "What we're testing: whether individuals will pay for hosted convenience over manual browser transfers."
+        "footnote": "For individuals who want hosted, scheduled transfers without keeping a tab open."
       },
       "business": {
         "name": "Business",
@@ -152,17 +152,17 @@
           "Migration previews and run reports",
           "Multiple workspace connections"
         ],
-        "footnote": "What we're testing: whether teams migrating workspaces value the preview, reports, and Cloud Runner enough to pay this tier."
+        "footnote": "For teams migrating a workspace or running multiple jobs in parallel."
       },
       "privateRunner": {
         "name": "Private Runner",
-        "price": "~$15",
+        "price": "~$6",
         "features": [
           "Run transfers on your own server, NAS, or VPS",
           "Bytes never touch Syncologic infrastructure",
           "Pay for the control plane, not for bandwidth"
         ],
-        "footnote": "What we're testing: whether privacy-minded users will pay a flat fee when they bring their own runner."
+        "footnote": "For users who bring their own infrastructure. Bytes and credentials stay with you."
       }
     },
     "affects": {
@@ -170,15 +170,15 @@
       "subtitle": "Three factors shape what your plan should look like.",
       "volume": {
         "title": "Data volume",
-        "body": "How much data moves per job and per month — the biggest single driver of bandwidth and storage cost."
+        "body": "The biggest single driver — how much data moves per job and per month."
       },
       "frequency": {
         "title": "Frequency",
-        "body": "One-time migrations cost differently than recurring backups. Continuous sync sits in its own bucket."
+        "body": "One-time migrations, recurring backups, and continuous sync each price differently."
       },
       "runner": {
         "title": "Runner choice",
-        "body": "Cloud Runner uses our bandwidth. Browser and Private Runner don't — so they cost less to operate."
+        "body": "Cloud Runner uses our bandwidth. Browser and Private Runner don't."
       }
     },
     "cloudVsPrivate": {
@@ -208,20 +208,20 @@
       ]
     },
     "earlyAccess": {
-      "headline": "Join now and shape the plans.",
-      "body": "We're not charging anyone yet. Waitlist members get early access and a direct say in which hypotheses become real plans.",
+      "headline": "Join now, lock in early access.",
+      "body": "Nobody pays yet. Waitlist members get the first invitations at launch.",
       "cta": "Join the waitlist"
     },
     "faq": {
       "title": "Common pricing questions",
       "items": [
         {
-          "q": "Is there really no firm price yet?",
-          "a": "Yes — these numbers are hypotheses we're testing. The waitlist is how we learn which ones map to real demand before we commit."
+          "q": "Are these prices final?",
+          "a": "The four-plan structure is set. Exact prices may shift at the margins before launch — that's why each tier shows a `~` instead of an exact number."
         },
         {
           "q": "Will the Private Runner cost more than the Cloud Runner?",
-          "a": "Probably less, because you bring the bandwidth. We expect a flat control-plane fee rather than per-GB pricing."
+          "a": "Less. You bring the bandwidth, so Private Runner is a flat control-plane fee instead of metered usage."
         },
         {
           "q": "What about open-source self-hosting?",
@@ -233,7 +233,7 @@
         },
         {
           "q": "What happens if my use case spans two plans?",
-          "a": "Tell us in the waitlist questions — that signal is exactly what we use to redraw plan boundaries before launch."
+          "a": "Pick the closer one and tell us in the waitlist questions. We'll reach out before launch if a different plan fits better."
         }
       ]
     }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -264,13 +264,13 @@
     "title": "Developers — automate cloud file transfers",
     "description": "Move files between clouds with a typed HTTP API, a CLI, webhooks, and runners you can host yourself.",
     "heroEyebrow": "For developers and platform teams",
-    "heroHeadline": "Automate cloud file transfers with an API, CLI, webhooks, and runners.",
-    "heroSubheading": "For agencies moving client assets, SaaS teams importing or exporting customer files, and internal tools that move bytes between provider APIs without writing the glue.",
+    "heroHeadline": "Move files between clouds with one API.",
+    "heroSubheading": "For agencies, SaaS teams, and internal tools that move files between cloud providers without writing the glue.",
     "heroPrimaryCta": "Join the developer waitlist",
     "heroSecondaryCta": "See the API",
     "audienceLabel": "Built for agencies, SaaS engineering teams, platform groups, and internal tooling.",
     "apiTitle": "A typed HTTP API",
-    "apiBody": "Create a job with a source, a destination, a runner choice, and an optional schedule. The control plane validates, picks a runner, and emits progress events.",
+    "apiBody": "Create a job with a source, destination, runner, and optional schedule. The control plane validates, dispatches, and emits progress events.",
     "apiCaption": "Sketch — final shape will land with the v1 API.",
     "cliTitle": "A CLI for scripts and CI",
     "cliBody": "Same jobs, driven from a terminal or a CI runner. Useful for one-shot migrations and for backups owned by a script you can read in a code review.",
@@ -294,15 +294,6 @@
     "webhookEventsLabel": "Planned events",
     "noSdkTitle": "No SDK promises yet",
     "noSdkBody": "We will not ship an official SDK before the API is stable. The OpenAPI spec will be public, so you can generate a typed client in any language you already use.",
-    "surveyTitle": "Which developer surface matters most to you?",
-    "surveyBody": "Pick the one you would reach for first. It helps us decide what ships first.",
-    "surveyOptions": {
-      "api": "HTTP API",
-      "cli": "CLI",
-      "webhooks": "Webhooks",
-      "selfHosted": "Self-hosting"
-    },
-    "surveyHint": "Local signal only — your pick is not sent anywhere. Use the waitlist below to share more.",
     "faqTitle": "Developer FAQ",
     "webhookEvents": [
       "job.created",
@@ -315,23 +306,24 @@
     "faq": [
       {
         "q": "When will the API ship?",
-        "a": "We are not committing to a date. The API will land alongside the first paid Cloud Runner tier. The waitlist is the right way to be first in line for early access."
+        "a": "We're not committing to a date. The API ships with the first paid Cloud Runner tier — join the waitlist for early access."
       },
       {
         "q": "Will there be a free tier for developers?",
-        "a": "The Browser Runner stays free, and the Private Runner is free for the runner itself. Cloud Runner usage is what we plan to bill for."
+        "a": "There's no special developer offer — everything you'd pay (or not pay) is in the current plans.",
+        "link": { "href": "/pricing", "label": "See pricing" }
       },
       {
         "q": "Do you handle OAuth on behalf of my users?",
-        "a": "Yes. The control plane handles provider OAuth so transfers can run unattended. Users connect their accounts through Syncologic, not through your app."
+        "a": "Yes. Users connect their cloud accounts to Syncologic — not to your app. You don't store provider credentials; the control plane manages the OAuth lifecycle."
       },
       {
         "q": "Can I run jobs entirely on my own infrastructure?",
-        "a": "Yes. The Private Runner runs in your VPC, on a NAS, or on a developer machine. The control plane never touches your file bytes."
+        "a": "Yes for the data path — Private Runner runs in your VPC, NAS, or any machine you control, and file bytes never reach Syncologic. The control plane (accounts, jobs, schedules) is hosted by us at launch; full self-host is on the roadmap."
       },
       {
         "q": "Are webhook payloads signed?",
-        "a": "Webhook payloads will be HMAC-signed with a per-workspace secret you control. Replay protection and timestamp tolerance follow the same conventions you would expect from Stripe or Linear."
+        "a": "Webhook payloads will be HMAC-signed with a per-workspace secret you control."
       }
     ]
   },

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -294,15 +294,6 @@
     "webhookEventsLabel": "Planned events",
     "noSdkTitle": "No SDK promises yet",
     "noSdkBody": "We will not ship an official SDK before the API is stable. The OpenAPI spec will be public, so you can generate a typed client in any language you already use.",
-    "surveyTitle": "Which developer surface matters most to you?",
-    "surveyBody": "Pick the one you would reach for first. It helps us decide what ships first.",
-    "surveyOptions": {
-      "api": "HTTP API",
-      "cli": "CLI",
-      "webhooks": "Webhooks",
-      "selfHosted": "Self-hosting"
-    },
-    "surveyHint": "Local signal only — your pick is not sent anywhere. Use the waitlist below to share more.",
     "faqTitle": "Developer FAQ",
     "webhookEvents": [
       "job.created",
@@ -319,7 +310,8 @@
       },
       {
         "q": "Will there be a free tier for developers?",
-        "a": "The Browser Runner stays free, and the Private Runner is free for the runner itself. Cloud Runner usage is what we plan to bill for."
+        "a": "There's no special developer offer — everything you'd pay (or not pay) is in the current plans.",
+        "link": { "href": "/pt-br/pricing", "label": "See pricing" }
       },
       {
         "q": "Do you handle OAuth on behalf of my users?",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -399,8 +399,7 @@
     },
     "sourceTrust": {
       "title": "Why core code stays public",
-      "body": "Runner code, transfer logic, and provider adapters are source-visible. You can audit how files move before trusting the system.",
-      "body2": "Private repos exist only for ops runbooks, security incidents, and business material — never for product code."
+      "body": "Runner code, transfer logic, and provider adapters are source-visible. You can audit how files move before trusting the system."
     }
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,7 +12,7 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     scroll-behavior: smooth;
-    scroll-padding-top: 24px;
+    scroll-padding-top: 80px;
   }
 
   body {


### PR DESCRIPTION
Phase A of [Plan 3](../blob/development/docs/superpowers/plans/2026-05-01-plan-3-polish-and-i18n.md). Walks every non-homepage page, tightens copy to obey the `≤ 2–3 lines per block` rule, and (in scope-creep that earned its keep) reframes tone and tense so the site stops sounding uncertain about its own product.

Closes #102.

## Per-page commits

| Commit | Page |
|---|---|
| 8761dfd | `/pricing` — trim + reframe (hypothesis-frame → "this is for you"); Private Runner corrected from `~$15` to `~$6` |
| fa7c163 | `/self-hosted` — tighten copy, fix timing ("today" → "at launch") and auth/credentials ambiguity (`Auth` → `Accounts`); resolve internal contradiction about which plane self-hosts first |
| be1d15d | `/developers` — rewrite copy, drop the dead localStorage survey + its plumbing, link FAQ to `/pricing` (FAQ component now supports optional inline link) |
| a0b9dcc | `/use-cases/cloud-to-cloud-transfer` — trim + future-tense framing |
| 352dc76 | `/use-cases/business-cloud-migration` — trim + future-tense framing |
| 235e796 | `/use-cases/scheduled-cloud-backup` — trim + future-tense framing |
| 6fd1e80 | `/use-cases/private-runner` — trim + future-tense framing |
| 161ea11 | `fix(scroll)` — bump `scroll-padding-top` from 24px to 80px so anchor links clear the sticky 64px navbar |
| 4f2ee37 | `/guides/move-files-between-clouds-without-downloading` — light tense fixes on the product-pitch section only (SEO body untouched) |
| cfd1af7 | `/guides/transfer-google-drive-to-onedrive` — same light treatment |

## What grew beyond the literal "copy trim" scope

The original Phase A spec was prose-length tightening, but reading each page exposed three classes of issue worth fixing in the same PR rather than queueing as follow-ups:

- **Tone — "we're testing hypotheses, help us decide".** The whole `/pricing` page read like internal pricing-strategy notes leaked into prod ("What we're testing:", "hypotheses become real plans", subtitle literally asking the visitor what they'd pay). Reframed every card footnote from "what we're testing" to "who this is for". Same fix pattern bled into `/developers`, `/self-hosted`, `/use-cases/*`.
- **Tense — present-tense capability claims about a pre-launch product.** Phrases like "Syncologic moves files…", "you watch progress live and get a completion report", "today against our hosted control plane", "are source-visible" all imply a shipped product. Switched body claims to future tense ("will move", "you'll watch", "at launch", "will ship source-visible"). Architectural / category descriptions (where a sentence describes a *type* of operation, not a Syncologic-now claim) stay present-tense by precedent.
- **Architectural ambiguity.** Resolved on `/self-hosted`: the page used to say the control plane is "what you'd self-host first" while the Future-self-host-levels section correctly said Private Runner ships first. Now the data-plane bullet carries the rollout claim ("self-host the runner from launch"), control-plane is "hosted by us at launch, self-hostable on the roadmap". Same fix replicated on `/use-cases/private-runner` and `/developers` Q4.

## Cross-page conventions established

- **`~$X` price ladder** is now consistent and ordered by cost-to-operate: `Free $0 < Private Runner ~$6 < Pro ~$9 < Business ~$29`. (Was `Free / Pro $9 / Business $29 / Private Runner $15` — Private Runner used to charge *more* than Pro despite using none of our bandwidth or compute.)
- **`Auth` → `Accounts`** in control-plane descriptions so a developer can't mistake it for provider OAuth tokens. The runner sections now specify "your provider credentials" where they used to say just "credentials".
- **`## How it works` → `## How it'll work`** on all four use-case pages (with matching `secondaryCta` href + label updates so the hero "See how it'll work" button still anchors correctly to the renamed section). Single section-heading change frames the imperative numbered steps below as future without rewriting each one.
- **`scroll-padding-top: 80px`** site-wide so anchor links clear the 64px sticky navbar with a 16px breathing gap. Was 24px, far too small.

## Mechanism changes (small, kept tight)

- `FAQ.astro` now accepts an optional `link?: { href, label }` field on `FaqItem`. When present, renders a brand-blue inline link after the answer. Used once so far on `/developers` Q2 → `/pricing`. Other FAQ items unchanged.
- `WaitlistForm.astro` lost the `extraQuestion` prop, the `ExtraQuestion` / `ExtraQuestionOption` interfaces, the on-page widget block, and the `.waitlist-extra-question` localStorage script. `/developers` was the only consumer, and the survey saved answers to localStorage instead of the waitlist payload — pure window dressing. ~50 lines of dead code removed.

## Out of scope — flagged for follow-up issues

- **Wire `preferred_developer_surface` as a real waitlist field** if/when we want to capture that segmentation signal for real (touches `validation.ts` enum, DB migration, taxonomy in `.claude/rules/architecture.md`, en + pt-br translations). Separate issue, separate PR.
- **Caveats mega-paragraphs** on both guide MDX bodies are structural, not content — Phase B½ (#111) restructures all guide bodies into the centered blog-post layout, so leaving those alone here is intentional.

## pt-BR

Phase A explicitly does **not** translate pt-BR (Phase C #112 retranslates wholesale). Two pt-br MDX edits in this PR were structural-parity only:

- Removed `selfHosted.sourceTrust.body2` from `pt-br.json` so the JSON shape matches `en.json` after the deletion.
- Removed `developers.surveyTitle/surveyBody/surveyHint/surveyOptions` from `pt-br.json` for the same reason.
- Added the `link` field to the `developers.faq[1]` item in `pt-br.json` with `href: "/pt-br/pricing"`. Localized URL, English placeholder label.

## Verification

- `npm run lint` — 0 errors, 0 warnings, 0 hints.
- `npm test` — 41/41 passing.
- `npm run build` — clean Vercel output, sitemap generated.
- **Visual verification**: every page (en) reviewed in a real browser at 1280px desktop, page by page, before each commit. Mobile/tablet pass is **not** covered by this PR — that's Phase D (#113). pt-BR mirrors not visually verified beyond confirming they still render (content stays placeholder English until Phase C).

## Test plan

- [x] Vercel preview builds clean.
- [x] Walk every page in the preview and confirm copy reads as expected (focus on `/pricing` tone shift, `/developers` FAQ link, the four use-case "See how it'll work" anchor scrolls landing below the navbar).
- [x] Confirm the dead `/developers` survey is gone and the WaitlistForm still works on every page that uses it (homepage + use-cases + bespoke).