### PR TITLE
feat(motion): shared scroll-reveal + hero entrance keyframes

### DIFF
--- a/src/components/layout/Layout.astro
+++ b/src/components/layout/Layout.astro
@@ -51,5 +51,30 @@ const og = ogImage ?? `${siteUrl}/og/default-${locale}.png`;
     </main>
     <slot name="footer" />
     <SpeedInsights />
+    <script>
+      const targets = document.querySelectorAll('[data-reveal]');
+      if (targets.length > 0) {
+        const reveal = (el: Element) => el.classList.add('is-visible');
+        if (
+          'IntersectionObserver' in window &&
+          !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ) {
+          const io = new IntersectionObserver(
+            (entries) => {
+              for (const entry of entries) {
+                if (entry.isIntersecting) {
+                  reveal(entry.target);
+                  io.unobserve(entry.target);
+                }
+              }
+            },
+            { threshold: 0.15, rootMargin: '0px 0px -10% 0px' },
+          );
+          targets.forEach((el) => io.observe(el));
+        } else {
+          targets.forEach(reveal);
+        }
+      }
+    </script>
   </body>
 </html>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -36,11 +36,16 @@ const subheadingClass =
   surface === 'dark'
     ? 'text-body text-white/80 max-w-[640px]'
     : 'text-body text-slate-gray max-w-[640px]';
+
+const hasVisual = Astro.slots.has('visual');
+const gridClass = hasVisual
+  ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,760px)_minmax(0,1fr)] gap-12 items-center'
+  : 'grid grid-cols-1 gap-12 items-center';
 ---
 
 <Section surface={surface} padding="lg" id={id}>
-  <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,760px)_minmax(0,1fr)] gap-12 items-center">
-    <div class="flex flex-col gap-6">
+  <div class={gridClass}>
+    <div class="flex flex-col gap-6 hero-fade-in">
       {eyebrow && <span class={eyebrowClass}>{eyebrow}</span>}
       <h1 class={headlineClass}>{headline}</h1>
       {subheading && <p class={subheadingClass}>{subheading}</p>}
@@ -52,8 +57,10 @@ const subheadingClass =
       </div>
       <slot name="meta" />
     </div>
-    <div>
-      <slot name="visual" />
-    </div>
+    {hasVisual && (
+      <div class="hero-fade-in" style="animation-delay: 120ms;">
+        <slot name="visual" />
+      </div>
+    )}
   </div>
 </Section>

--- a/src/components/ui/RevealOnScroll.astro
+++ b/src/components/ui/RevealOnScroll.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+  as?: keyof HTMLElementTagNameMap;
+  class?: string;
+  delay?: number;
+}
+
+const { as: Tag = 'div', class: className, delay } = Astro.props;
+const style = delay ? `transition-delay: ${delay}ms;` : undefined;
+---
+
+<Tag data-reveal class={className} style={style}>
+  <slot />
+</Tag>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -40,6 +40,28 @@
   }
 }
 
+/* Scroll-reveal + hero entrance motion (Phase B0) */
+@keyframes hero-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+
+.hero-fade-in {
+  animation: hero-fade-in 600ms ease both;
+}
+
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 600ms ease, transform 600ms ease;
+  will-change: opacity, transform;
+}
+
+[data-reveal].is-visible {
+  opacity: 1;
+  transform: none;
+}
+
 /* Site-wide reduced motion: disables non-essential animation */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
@@ -47,6 +69,15 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+  .hero-fade-in {
+    animation: none;
+  }
+  [data-reveal],
+  [data-reveal].is-visible {
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Phase B0 motion foundation per [Plan 3 § Phase B foundation](https://github.com/Syncologic/marketing-site/blob/development/docs/superpowers/plans/2026-05-01-plan-3-polish-and-i18n.md#phase-b-foundation-b0). Ships the shared scroll-reveal + hero entrance infrastructure every per-page hero visual (B1–B7) will mount on top of.

- **`src/components/ui/RevealOnScroll.astro`** — wrapper that adds `data-reveal` to its slot's root. Optional `as` tag + `delay` (transition-delay) prop.
- **`src/styles/global.css`** — `@keyframes hero-fade-in`, `[data-reveal]` reset + `.is-visible` end state (~600ms ease), and a `prefers-reduced-motion: reduce` guard that disables both.
- **`src/components/layout/Layout.astro`** — one shared `IntersectionObserver` script at the bottom of `<body>`. Threshold `0.15`, `rootMargin: '0px 0px -10% 0px'`, `once: true` (via `unobserve`). Bails early if there are no `[data-reveal]` elements; falls back to immediate reveal when `IntersectionObserver` is missing or `prefers-reduced-motion` is on.
- **`src/components/sections/Hero.astro`** — detects empty `visual` slot via `Astro.slots.has('visual')` and collapses the grid to a single column. Applies `.hero-fade-in` to the headline column + visual column, with a 120ms `animation-delay` on the visual to stagger the entrance.

## Verification

- `npm run lint` — 0 errors, 0 warnings, 1 hint.
- `npm test` — 41 passing across 4 files.
- `npm run build` — clean; site builds with all routes generated.
- Inline reveal script weighs **286 bytes gzipped** (408 raw), well under the 1 KB target and far below the 20 KB/page client-JS budget.
- **Manually verified `prefers-reduced-motion: reduce`** in DevTools (Rendering panel → "Emulate CSS media feature prefers-reduced-motion" → `reduce`, then reload). Hero headline + visual render at full opacity with no transform, and `[data-reveal]` elements appear immediately without scroll-triggered animation. Reduced-motion behavior is encoded both in CSS (`@media (prefers-reduced-motion: reduce)` overrides `[data-reveal]` opacity/transform + disables `.hero-fade-in` animation) and in the IO script (skips observer setup and reveals all targets immediately when the media query matches).

Closes #103