### PR TITLE
feat(visuals): cloud-to-cloud-transfer hero visual

### DIFF
--- a/src/components/visuals/ProviderArc.astro
+++ b/src/components/visuals/ProviderArc.astro
@@ -1,0 +1,108 @@
+---
+import ProviderLogo from '../ui/ProviderLogo.astro';
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const altLabel = t('visuals.providerArc.alt');
+---
+
+<div class="provider-arc relative w-full max-w-[480px] mx-auto" role="presentation">
+  <svg
+    viewBox="0 0 480 480"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label={altLabel}
+    class="w-full h-auto block"
+  >
+    <rect x="40" y="180" width="120" height="120" rx="20" class="fill-warm-gray" />
+    <rect x="320" y="180" width="120" height="120" rx="20" class="fill-warm-gray" />
+
+    <path
+      d="M 100 240 Q 240 80 380 240"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="arc-flow stroke-divider"
+    />
+    <path
+      d="M 100 240 Q 240 80 380 240"
+      fill="none"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      class="stroke-brand-blue"
+    />
+
+    <g transform="translate(56 196)">
+      <ProviderLogo provider="google-drive" size={88} />
+    </g>
+    <g transform="translate(336 196)">
+      <ProviderLogo provider="onedrive" size={88} />
+    </g>
+
+    <g class="file-pills" aria-hidden="true">
+      <g class="file-pill" style="--pill-delay: 0s;">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-divider" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+      </g>
+      <g class="file-pill" style="--pill-delay: 0.45s;">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-divider" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+      </g>
+      <g class="file-pill" style="--pill-delay: 0.9s;">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-divider" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+      </g>
+    </g>
+  </svg>
+</div>
+
+<style>
+  .provider-arc { min-width: 320px; }
+
+  @media (max-width: 1023px) {
+    .provider-arc { margin-block: -2rem -5rem; }
+  }
+  @media (max-width: 639px) {
+    .provider-arc { min-width: 0; max-width: 360px; margin-block: -3rem -6rem; }
+  }
+
+  .file-pill {
+    offset-path: path('M 100 240 Q 240 80 380 240');
+    offset-distance: 0%;
+    offset-rotate: 0deg;
+    opacity: 0;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .file-pill {
+      animation: provider-arc-pill 5s ease-in-out infinite;
+      animation-delay: var(--pill-delay, 0s);
+    }
+    .arc-flow {
+      animation: provider-arc-flow 1.6s linear infinite;
+    }
+
+    @keyframes provider-arc-pill {
+      0%   { offset-distance: 0%;   opacity: 0; }
+      8%   { offset-distance: 4%;   opacity: 1; }
+      72%  { offset-distance: 100%; opacity: 1; }
+      80%  { offset-distance: 100%; opacity: 0; }
+      100% { offset-distance: 100%; opacity: 0; }
+    }
+    @keyframes provider-arc-flow {
+      to { stroke-dashoffset: -16; }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .file-pill { opacity: 1; }
+    .file-pill:nth-child(1) { offset-distance: 30%; }
+    .file-pill:nth-child(2) { offset-distance: 50%; }
+    .file-pill:nth-child(3) { offset-distance: 70%; }
+  }
+</style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -101,6 +101,11 @@
     "indexTitle": "Use cases",
     "indexDescription": "Pick the workflow that matches what you're trying to do."
   },
+  "visuals": {
+    "providerArc": {
+      "alt": "Files moving from Google Drive to OneDrive along a connecting arc."
+    }
+  },
   "guides": {
     "indexTitle": "Guides",
     "indexDescription": "How to move files between cloud providers without downloading them first."

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -101,6 +101,11 @@
     "indexTitle": "Use cases",
     "indexDescription": "Pick the workflow that matches what you're trying to do."
   },
+  "visuals": {
+    "providerArc": {
+      "alt": "Files moving from Google Drive to OneDrive along a connecting arc."
+    }
+  },
   "guides": {
     "indexTitle": "Guides",
     "indexDescription": "How to move files between cloud providers without downloading them first."

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -6,6 +6,11 @@ import Footer from '../../../components/layout/Footer.astro';
 import Hero from '../../../components/sections/Hero.astro';
 import WaitlistForm from '../../../components/sections/WaitlistForm.astro';
 import StickyWaitlistBar from '../../../components/sections/StickyWaitlistBar.astro';
+import ProviderArc from '../../../components/visuals/ProviderArc.astro';
+
+const visualMap: Record<string, typeof ProviderArc | undefined> = {
+  'cloud-to-cloud-transfer': ProviderArc,
+};
 
 export async function getStaticPaths() {
   const entries = await getCollection('use-cases', (e) => e.data.locale === 'pt-br');
@@ -18,6 +23,8 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await entry.render();
 const ogImage = entry.data.ogImage ?? '/og/default-pt-br.png';
+const slug = entry.slug.replace(/^pt-br\//, '');
+const Visual = visualMap[slug];
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
@@ -28,7 +35,13 @@ const ogImage = entry.data.ogImage ?? '/og/default-pt-br.png';
     subheading={entry.data.subheading}
     primaryCta={entry.data.primaryCta}
     secondaryCta={entry.data.secondaryCta}
-  />
+  >
+    {Visual && (
+      <Fragment slot="visual">
+        <Visual />
+      </Fragment>
+    )}
+  </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
     <Content />
   </article>

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -6,6 +6,11 @@ import Footer from '../../components/layout/Footer.astro';
 import Hero from '../../components/sections/Hero.astro';
 import WaitlistForm from '../../components/sections/WaitlistForm.astro';
 import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro';
+import ProviderArc from '../../components/visuals/ProviderArc.astro';
+
+const visualMap: Record<string, typeof ProviderArc | undefined> = {
+  'cloud-to-cloud-transfer': ProviderArc,
+};
 
 export async function getStaticPaths() {
   const entries = await getCollection('use-cases', (e) => e.data.locale === 'en');
@@ -18,6 +23,8 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await entry.render();
 const ogImage = entry.data.ogImage ?? '/og/default-en.png';
+const slug = entry.slug.replace(/^en\//, '');
+const Visual = visualMap[slug];
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
@@ -28,7 +35,13 @@ const ogImage = entry.data.ogImage ?? '/og/default-en.png';
     subheading={entry.data.subheading}
     primaryCta={entry.data.primaryCta}
     secondaryCta={entry.data.secondaryCta}
-  />
+  >
+    {Visual && (
+      <Fragment slot="visual">
+        <Visual />
+      </Fragment>
+    )}
+  </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
     <Content />
   </article>


### PR DESCRIPTION
## Summary

- Adds `src/components/visuals/ProviderArc.astro` — pure SVG, zero JS, zero props.
- Mounts it via a slug-dispatched `visualMap` on `src/pages/use-cases/[slug].astro` and the pt-BR mirror.
- Adds `visuals.providerArc.alt` to `en.json` and `pt-br.json` (English placeholder in pt-br per Plan 3 phase order — Phase C replaces).

## What it looks like

Two `bg-warm-gray` provider tiles (Google Drive on the left, OneDrive on the right) connected by a 1.5px brand-blue arc, with a dotted divider-color underlay flowing left-to-right. Three file-card pills travel along the arc on a 5-second loop (~4s slide + 1s pause), staggered by 450ms. Pills use `offset-path: path(...)` so the motion respects `prefers-reduced-motion: reduce` cleanly — under reduced-motion the pills sit statically at 30% / 50% / 70% along the arc.

Negative `margin-block` at `<lg` pulls the visual into the hero gap and tightens the section bottom so it doesn't leave dead space below the SVG on mobile.

## Notes / trade-offs

- **Inline SVG size:** ~23 KB raw (largely the OneDrive `ProviderLogo`'s 8 radialGradients). Over the 6 KB plan guideline, but reusing `ProviderLogo` keeps brand visuals consistent and avoids inline-hex violations from a hand-rolled glyph. Gzipped delta is much smaller.
- **No client JS added.** Animation is pure CSS keyframes + `offset-path`.
- **i18n placeholder copy** in `pt-br.json` is intentional per the Plan 3 phase order (Phase C replaces).

## Verification

- `npm run lint` → 0 errors, 0 warnings.
- `npm test` → 41/41 passing.
- `npm run build` → clean.
- Real-browser pass at `lg` / `md` / `sm` performed by repo maintainer; iterated on mobile spacing until the gap to the next section was acceptable.
- `prefers-reduced-motion: reduce` verified to render a static end-state (pills positioned along the arc, no animation).

Closes #104

Plan reference: [\`docs/superpowers/plans/2026-05-01-plan-3-polish-and-i18n.md\` § B1](https://github.com/Syncologic/marketing-site/blob/development/docs/superpowers/plans/2026-05-01-plan-3-polish-and-i18n.md#b1--providerarcastro-for-use-casescloud-to-cloud-transfer)