### PR TITLE
feat(visuals): scheduled-cloud-backup hero visual

### DIFF
--- a/src/components/visuals/ScheduleClock.astro
+++ b/src/components/visuals/ScheduleClock.astro
@@ -1,0 +1,140 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const altLabel = t('visuals.scheduleClock.alt');
+const nextRunLabel = t('visuals.scheduleClock.nextRun');
+
+const CELLS = Array.from({ length: 28 }, (_, i) => {
+  const col = i % 7;
+  const row = Math.floor(i / 7);
+  return {
+    x: 13 + col * 66,
+    y: 122 + row * 66,
+    cx: 13 + col * 66 + 29,
+    cy: 122 + row * 66 + 29,
+    date: i + 1,
+  };
+});
+
+const HIGHLIGHT_COL = 2;
+const HIGHLIGHT_ROWS = [0, 1, 2];
+---
+
+<div class="schedule-clock relative w-full max-w-[480px] mx-auto" role="presentation">
+  <svg
+    viewBox="0 0 480 480"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label={altLabel}
+    class="w-full h-auto block"
+  >
+    <g class="sc-pill" aria-hidden="true">
+      <rect x="120" y="16" width="240" height="40" rx="20" class="fill-baby-blue" />
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-t1 fill-brand-blue">{nextRunLabel} · 12h 04m</text>
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-t2 fill-brand-blue">{nextRunLabel} · 06h 21m</text>
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-t3 fill-brand-blue">{nextRunLabel} · 01h 12m</text>
+    </g>
+
+    <g class="sc-dow" aria-hidden="true">
+      <text x="42"  y="100" class="sc-dow-text fill-slate-gray">M</text>
+      <text x="108" y="100" class="sc-dow-text fill-slate-gray">T</text>
+      <text x="174" y="100" class="sc-dow-text fill-slate-gray">W</text>
+      <text x="240" y="100" class="sc-dow-text fill-slate-gray">T</text>
+      <text x="306" y="100" class="sc-dow-text fill-slate-gray">F</text>
+      <text x="372" y="100" class="sc-dow-text fill-slate-gray">S</text>
+      <text x="438" y="100" class="sc-dow-text fill-slate-gray">S</text>
+    </g>
+
+    <g class="sc-cells" aria-hidden="true">
+      {CELLS.map((c) => (
+        <g>
+          <rect x={c.x} y={c.y} width="58" height="58" rx="10" stroke-width="1" class="fill-warm-gray stroke-divider" />
+          <text x={c.cx} y={c.cy + 6} class="sc-cell-num fill-slate-gray">{c.date}</text>
+        </g>
+      ))}
+    </g>
+
+    <g class="sc-hl-layer" aria-hidden="true">
+      {HIGHLIGHT_ROWS.map((row) => {
+        const cell = CELLS[row * 7 + HIGHLIGHT_COL];
+        return (
+          <g class={`sc-hl sc-hl-${row}`}>
+            <circle cx={cell.cx} cy={cell.cy} r="34" fill-opacity="0.06" class="fill-brand-blue" />
+            <circle cx={cell.cx} cy={cell.cy} r="26" fill-opacity="0.10" class="fill-brand-blue" />
+            <circle cx={cell.cx} cy={cell.cy} r="20" fill-opacity="0.14" class="fill-brand-blue" />
+            <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" class="stroke-brand-blue" />
+            <circle cx={cell.cx} cy={cell.cy + 18} r="3" class="fill-brand-blue" />
+          </g>
+        );
+      })}
+    </g>
+  </svg>
+</div>
+
+<style>
+  .schedule-clock { min-width: 320px; }
+
+  @media (max-width: 1023px) {
+    .schedule-clock { margin-block: -1rem -2rem; }
+  }
+  @media (max-width: 639px) {
+    .schedule-clock { min-width: 0; max-width: 360px; margin-block: -1rem -3rem; }
+  }
+
+  .sc-pill-text {
+    font-size: 14px;
+    font-weight: 500;
+    font-family: inherit;
+  }
+  .sc-dow-text {
+    font-size: 13px;
+    font-weight: 600;
+    text-anchor: middle;
+    letter-spacing: 0.06em;
+  }
+  .sc-cell-num {
+    font-size: 14px;
+    font-weight: 500;
+    text-anchor: middle;
+  }
+
+  .sc-pill-text { opacity: 0; }
+  .sc-pill-text.sc-t1 { opacity: 1; }
+  .sc-hl { opacity: 0; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .sc-pill-text.sc-t1 { animation: sc-t1 5s steps(1, end) infinite; }
+    .sc-pill-text.sc-t2 { animation: sc-t2 5s steps(1, end) infinite; }
+    .sc-pill-text.sc-t3 { animation: sc-t3 5s steps(1, end) infinite; }
+    .sc-hl-0 { animation: sc-hl 5s ease-in-out infinite; animation-delay: 0s; }
+    .sc-hl-1 { animation: sc-hl 5s ease-in-out infinite; animation-delay: 1.667s; }
+    .sc-hl-2 { animation: sc-hl 5s ease-in-out infinite; animation-delay: 3.333s; }
+
+    @keyframes sc-t1 {
+      0%, 33%      { opacity: 1; }
+      33.01%, 100% { opacity: 0; }
+    }
+    @keyframes sc-t2 {
+      0%, 33%      { opacity: 0; }
+      33.01%, 66%  { opacity: 1; }
+      66.01%, 100% { opacity: 0; }
+    }
+    @keyframes sc-t3 {
+      0%, 66%      { opacity: 0; }
+      66.01%, 100% { opacity: 1; }
+    }
+    @keyframes sc-hl {
+      0%   { opacity: 0; }
+      6%   { opacity: 1; }
+      28%  { opacity: 1; }
+      33%  { opacity: 0; }
+      100% { opacity: 0; }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sc-hl { opacity: 1; }
+  }
+</style>

--- a/src/components/visuals/ScheduleClock.astro
+++ b/src/components/visuals/ScheduleClock.astro
@@ -4,7 +4,7 @@ import { getLocaleFromUrl, getT } from '../../i18n/utils';
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 const altLabel = t('visuals.scheduleClock.alt');
-const nextRunLabel = t('visuals.scheduleClock.nextRun');
+const todayLabel = t('visuals.scheduleClock.today');
 
 const CELLS = Array.from({ length: 28 }, (_, i) => {
   const col = i % 7;
@@ -18,8 +18,7 @@ const CELLS = Array.from({ length: 28 }, (_, i) => {
   };
 });
 
-const HIGHLIGHT_COL = 2;
-const HIGHLIGHT_ROWS = [0, 1, 2];
+const SCHEDULED = [0, 1, 2].map((row) => CELLS[row * 7 + 2]);
 ---
 
 <div class="schedule-clock relative w-full max-w-[480px] mx-auto" role="presentation">
@@ -32,9 +31,10 @@ const HIGHLIGHT_ROWS = [0, 1, 2];
   >
     <g class="sc-pill" aria-hidden="true">
       <rect x="120" y="16" width="240" height="40" rx="20" class="fill-baby-blue" />
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-t1 fill-brand-blue">{nextRunLabel} · 12h 04m</text>
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-t2 fill-brand-blue">{nextRunLabel} · 06h 21m</text>
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-t3 fill-brand-blue">{nextRunLabel} · 01h 12m</text>
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p1 fill-brand-blue">{todayLabel} · Mar 1</text>
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p2 fill-brand-blue">{todayLabel} · Mar 5</text>
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p3 fill-brand-blue">{todayLabel} · Mar 12</text>
+      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p4 fill-brand-blue">{todayLabel} · Mar 18</text>
     </g>
 
     <g class="sc-dow" aria-hidden="true">
@@ -57,18 +57,20 @@ const HIGHLIGHT_ROWS = [0, 1, 2];
     </g>
 
     <g class="sc-hl-layer" aria-hidden="true">
-      {HIGHLIGHT_ROWS.map((row) => {
-        const cell = CELLS[row * 7 + HIGHLIGHT_COL];
-        return (
-          <g class={`sc-hl sc-hl-${row}`}>
-            <circle cx={cell.cx} cy={cell.cy} r="34" fill-opacity="0.06" class="fill-brand-blue" />
-            <circle cx={cell.cx} cy={cell.cy} r="26" fill-opacity="0.10" class="fill-brand-blue" />
-            <circle cx={cell.cx} cy={cell.cy} r="20" fill-opacity="0.14" class="fill-brand-blue" />
+      {SCHEDULED.map((cell, i) => (
+        <g class={`sc-slot sc-s${i + 1}`}>
+          <g class="sc-blue">
+            <circle cx={cell.cx} cy={cell.cy} r="22" fill-opacity="0.10" class="fill-brand-blue" />
             <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" class="stroke-brand-blue" />
             <circle cx={cell.cx} cy={cell.cy + 18} r="3" class="fill-brand-blue" />
           </g>
-        );
-      })}
+          <g class="sc-green">
+            <circle cx={cell.cx} cy={cell.cy} r="22" fill-opacity="0.12" class="fill-success" />
+            <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" class="stroke-success" />
+            <circle cx={cell.cx} cy={cell.cy + 18} r="3" class="fill-success" />
+          </g>
+        </g>
+      ))}
     </g>
   </svg>
 </div>
@@ -101,40 +103,42 @@ const HIGHLIGHT_ROWS = [0, 1, 2];
   }
 
   .sc-pill-text { opacity: 0; }
-  .sc-pill-text.sc-t1 { opacity: 1; }
-  .sc-hl { opacity: 0; }
+  .sc-pill-text.sc-p1 { opacity: 1; }
+  .sc-blue { opacity: 1; }
+  .sc-green { opacity: 0; }
 
+  /* 10 s loop: 0–7 s sequence (3 dots turn green as Today advances),
+     7–10 s hold all-green before snapping back. */
   @media (prefers-reduced-motion: no-preference) {
-    .sc-pill-text.sc-t1 { animation: sc-t1 5s steps(1, end) infinite; }
-    .sc-pill-text.sc-t2 { animation: sc-t2 5s steps(1, end) infinite; }
-    .sc-pill-text.sc-t3 { animation: sc-t3 5s steps(1, end) infinite; }
-    .sc-hl-0 { animation: sc-hl 5s ease-in-out infinite; animation-delay: 0s; }
-    .sc-hl-1 { animation: sc-hl 5s ease-in-out infinite; animation-delay: 1.667s; }
-    .sc-hl-2 { animation: sc-hl 5s ease-in-out infinite; animation-delay: 3.333s; }
+    .sc-pill-text.sc-p1 { animation: sc-p1 10s steps(1, end) infinite; }
+    .sc-pill-text.sc-p2 { animation: sc-p2 10s steps(1, end) infinite; }
+    .sc-pill-text.sc-p3 { animation: sc-p3 10s steps(1, end) infinite; }
+    .sc-pill-text.sc-p4 { animation: sc-p4 10s steps(1, end) infinite; }
 
-    @keyframes sc-t1 {
-      0%, 33%      { opacity: 1; }
-      33.01%, 100% { opacity: 0; }
-    }
-    @keyframes sc-t2 {
-      0%, 33%      { opacity: 0; }
-      33.01%, 66%  { opacity: 1; }
-      66.01%, 100% { opacity: 0; }
-    }
-    @keyframes sc-t3 {
-      0%, 66%      { opacity: 0; }
-      66.01%, 100% { opacity: 1; }
-    }
-    @keyframes sc-hl {
-      0%   { opacity: 0; }
-      6%   { opacity: 1; }
-      28%  { opacity: 1; }
-      33%  { opacity: 0; }
-      100% { opacity: 0; }
-    }
+    .sc-s1 .sc-blue  { animation: sc-blue-1  10s steps(1, end) infinite; }
+    .sc-s1 .sc-green { animation: sc-green-1 10s steps(1, end) infinite; }
+    .sc-s2 .sc-blue  { animation: sc-blue-2  10s steps(1, end) infinite; }
+    .sc-s2 .sc-green { animation: sc-green-2 10s steps(1, end) infinite; }
+    .sc-s3 .sc-blue  { animation: sc-blue-3  10s steps(1, end) infinite; }
+    .sc-s3 .sc-green { animation: sc-green-3 10s steps(1, end) infinite; }
+
+    @keyframes sc-p1 { 0%, 15%      { opacity: 1; } 15.01%, 100% { opacity: 0; } }
+    @keyframes sc-p2 { 0%, 15%      { opacity: 0; } 15.01%, 35%  { opacity: 1; } 35.01%, 100% { opacity: 0; } }
+    @keyframes sc-p3 { 0%, 35%      { opacity: 0; } 35.01%, 55%  { opacity: 1; } 55.01%, 100% { opacity: 0; } }
+    @keyframes sc-p4 { 0%, 55%      { opacity: 0; } 55.01%, 100% { opacity: 1; } }
+
+    @keyframes sc-blue-1  { 0%, 15%   { opacity: 1; } 15.01%, 100% { opacity: 0; } }
+    @keyframes sc-green-1 { 0%, 15%   { opacity: 0; } 15.01%, 100% { opacity: 1; } }
+    @keyframes sc-blue-2  { 0%, 35%   { opacity: 1; } 35.01%, 100% { opacity: 0; } }
+    @keyframes sc-green-2 { 0%, 35%   { opacity: 0; } 35.01%, 100% { opacity: 1; } }
+    @keyframes sc-blue-3  { 0%, 55%   { opacity: 1; } 55.01%, 100% { opacity: 0; } }
+    @keyframes sc-green-3 { 0%, 55%   { opacity: 0; } 55.01%, 100% { opacity: 1; } }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .sc-hl { opacity: 1; }
+    .sc-pill-text.sc-p1 { opacity: 0; }
+    .sc-pill-text.sc-p4 { opacity: 1; }
+    .sc-blue  { opacity: 0; }
+    .sc-green { opacity: 1; }
   }
 </style>

--- a/src/components/visuals/ScheduleClock.astro
+++ b/src/components/visuals/ScheduleClock.astro
@@ -4,78 +4,77 @@ import { getLocaleFromUrl, getT } from '../../i18n/utils';
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 const altLabel = t('visuals.scheduleClock.alt');
-const todayLabel = t('visuals.scheduleClock.today');
 
-const CELLS = Array.from({ length: 28 }, (_, i) => {
-  const col = i % 7;
-  const row = Math.floor(i / 7);
+const COLS = 7;
+const ROWS = 4;
+const CELL = 58;
+const STRIDE = 66;
+const ORIGIN_X = 13;
+const ORIGIN_Y = 70;
+
+const CELLS = Array.from({ length: COLS * ROWS }, (_, i) => {
+  const col = i % COLS;
+  const row = Math.floor(i / COLS);
   return {
-    x: 13 + col * 66,
-    y: 122 + row * 66,
-    cx: 13 + col * 66 + 29,
-    cy: 122 + row * 66 + 29,
+    x: ORIGIN_X + col * STRIDE,
+    y: ORIGIN_Y + row * STRIDE,
+    cx: ORIGIN_X + col * STRIDE + CELL / 2,
+    cy: ORIGIN_Y + row * STRIDE + CELL / 2,
     date: i + 1,
   };
 });
 
-const SCHEDULED = [0, 1, 2].map((row) => CELLS[row * 7 + 2]);
+const SCHEDULED = [CELLS[2], CELLS[9], CELLS[16]];
+const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 ---
 
 <div class="schedule-clock relative w-full max-w-[480px] mx-auto" role="presentation">
   <svg
-    viewBox="0 0 480 480"
+    viewBox="0 0 480 410"
     xmlns="http://www.w3.org/2000/svg"
     role="img"
     aria-label={altLabel}
     class="w-full h-auto block"
   >
-    <g class="sc-pill" aria-hidden="true">
-      <rect x="120" y="16" width="240" height="40" rx="20" class="fill-baby-blue" />
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p1 fill-brand-blue">{todayLabel} · Mar 1</text>
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p2 fill-brand-blue">{todayLabel} · Mar 5</text>
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p3 fill-brand-blue">{todayLabel} · Mar 12</text>
-      <text x="240" y="41" text-anchor="middle" class="sc-pill-text sc-p4 fill-brand-blue">{todayLabel} · Mar 18</text>
-    </g>
-
-    <g class="sc-dow" aria-hidden="true">
-      <text x="42"  y="100" class="sc-dow-text fill-slate-gray">M</text>
-      <text x="108" y="100" class="sc-dow-text fill-slate-gray">T</text>
-      <text x="174" y="100" class="sc-dow-text fill-slate-gray">W</text>
-      <text x="240" y="100" class="sc-dow-text fill-slate-gray">T</text>
-      <text x="306" y="100" class="sc-dow-text fill-slate-gray">F</text>
-      <text x="372" y="100" class="sc-dow-text fill-slate-gray">S</text>
-      <text x="438" y="100" class="sc-dow-text fill-slate-gray">S</text>
-    </g>
-
-    <g class="sc-cells" aria-hidden="true">
-      {CELLS.map((c) => (
-        <g>
-          <rect x={c.x} y={c.y} width="58" height="58" rx="10" stroke-width="1" class="fill-warm-gray stroke-divider" />
-          <text x={c.cx} y={c.cy + 6} class="sc-cell-num fill-slate-gray">{c.date}</text>
-        </g>
+    <g class="sc-dow-text fill-slate-gray" aria-hidden="true">
+      {DOW.map((d, i) => (
+        <text x={42 + i * STRIDE} y="44">{d}</text>
       ))}
     </g>
 
-    <g class="sc-hl-layer" aria-hidden="true">
+    <g class="fill-warm-gray stroke-divider" stroke-width="1" aria-hidden="true">
+      {CELLS.map((c) => (
+        <rect x={c.x} y={c.y} width="58" height="58" rx="10" />
+      ))}
+    </g>
+    <g class="sc-cell-num fill-slate-gray" aria-hidden="true">
+      {CELLS.map((c) => (
+        <text x={c.cx} y={c.cy + 6}>{c.date}</text>
+      ))}
+    </g>
+
+    <g aria-hidden="true">
       {SCHEDULED.map((cell, i) => (
         <g class={`sc-slot sc-s${i + 1}`}>
-          <g class="sc-blue">
-            <circle cx={cell.cx} cy={cell.cy} r="22" fill-opacity="0.10" class="fill-brand-blue" />
-            <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" class="stroke-brand-blue" />
-            <circle cx={cell.cx} cy={cell.cy + 18} r="3" class="fill-brand-blue" />
+          <g class="sc-blue fill-brand-blue stroke-brand-blue">
+            <circle cx={cell.cx} cy={cell.cy} r="22" fill-opacity="0.10" stroke="none" />
+            <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" />
+            <circle cx={cell.cx} cy={cell.cy + 18} r="3" stroke="none" class="sc-dot" />
           </g>
-          <g class="sc-green">
-            <circle cx={cell.cx} cy={cell.cy} r="22" fill-opacity="0.12" class="fill-success" />
-            <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" class="stroke-success" />
-            <circle cx={cell.cx} cy={cell.cy + 18} r="3" class="fill-success" />
+          <g class="sc-green fill-success stroke-success">
+            <circle cx={cell.cx} cy={cell.cy} r="22" fill-opacity="0.12" stroke="none" />
+            <rect x={cell.x} y={cell.y} width="58" height="58" rx="10" fill="none" stroke-width="1.5" />
+            <circle cx={cell.cx} cy={cell.cy + 18} r="3" stroke="none" />
           </g>
         </g>
       ))}
     </g>
+
+    <rect class="sc-cursor stroke-dark-charcoal" x="13" y="70" width="58" height="58" rx="10" fill="none" stroke-width="2" />
   </svg>
 </div>
 
-<style>
+<style is:global>
   .schedule-clock { min-width: 320px; }
 
   @media (max-width: 1023px) {
@@ -85,11 +84,6 @@ const SCHEDULED = [0, 1, 2].map((row) => CELLS[row * 7 + 2]);
     .schedule-clock { min-width: 0; max-width: 360px; margin-block: -1rem -3rem; }
   }
 
-  .sc-pill-text {
-    font-size: 14px;
-    font-weight: 500;
-    font-family: inherit;
-  }
   .sc-dow-text {
     font-size: 13px;
     font-weight: 600;
@@ -102,43 +96,60 @@ const SCHEDULED = [0, 1, 2].map((row) => CELLS[row * 7 + 2]);
     text-anchor: middle;
   }
 
-  .sc-pill-text { opacity: 0; }
-  .sc-pill-text.sc-p1 { opacity: 1; }
   .sc-blue { opacity: 1; }
   .sc-green { opacity: 0; }
+  .sc-dot { transform-box: fill-box; transform-origin: center; }
+  .sc-cursor { opacity: 0.9; }
 
-  /* 10 s loop: 0–7 s sequence (3 dots turn green as Today advances),
-     7–10 s hold all-green before snapping back. */
+  /* 11.5 s loop. Cursor walks 28 cells: 25 short hops (~0.21 s) + 3 transfer
+     stops (~1.5 s each) + 1.5 s "all-done" hold before snapping back. */
   @media (prefers-reduced-motion: no-preference) {
-    .sc-pill-text.sc-p1 { animation: sc-p1 10s steps(1, end) infinite; }
-    .sc-pill-text.sc-p2 { animation: sc-p2 10s steps(1, end) infinite; }
-    .sc-pill-text.sc-p3 { animation: sc-p3 10s steps(1, end) infinite; }
-    .sc-pill-text.sc-p4 { animation: sc-p4 10s steps(1, end) infinite; }
+    .sc-cursor { animation: sc-cursor 11.5s steps(1, end) infinite; }
 
-    .sc-s1 .sc-blue  { animation: sc-blue-1  10s steps(1, end) infinite; }
-    .sc-s1 .sc-green { animation: sc-green-1 10s steps(1, end) infinite; }
-    .sc-s2 .sc-blue  { animation: sc-blue-2  10s steps(1, end) infinite; }
-    .sc-s2 .sc-green { animation: sc-green-2 10s steps(1, end) infinite; }
-    .sc-s3 .sc-blue  { animation: sc-blue-3  10s steps(1, end) infinite; }
-    .sc-s3 .sc-green { animation: sc-green-3 10s steps(1, end) infinite; }
-
-    @keyframes sc-p1 { 0%, 15%      { opacity: 1; } 15.01%, 100% { opacity: 0; } }
-    @keyframes sc-p2 { 0%, 15%      { opacity: 0; } 15.01%, 35%  { opacity: 1; } 35.01%, 100% { opacity: 0; } }
-    @keyframes sc-p3 { 0%, 35%      { opacity: 0; } 35.01%, 55%  { opacity: 1; } 55.01%, 100% { opacity: 0; } }
-    @keyframes sc-p4 { 0%, 55%      { opacity: 0; } 55.01%, 100% { opacity: 1; } }
-
-    @keyframes sc-blue-1  { 0%, 15%   { opacity: 1; } 15.01%, 100% { opacity: 0; } }
-    @keyframes sc-green-1 { 0%, 15%   { opacity: 0; } 15.01%, 100% { opacity: 1; } }
-    @keyframes sc-blue-2  { 0%, 35%   { opacity: 1; } 35.01%, 100% { opacity: 0; } }
-    @keyframes sc-green-2 { 0%, 35%   { opacity: 0; } 35.01%, 100% { opacity: 1; } }
-    @keyframes sc-blue-3  { 0%, 55%   { opacity: 1; } 55.01%, 100% { opacity: 0; } }
-    @keyframes sc-green-3 { 0%, 55%   { opacity: 0; } 55.01%, 100% { opacity: 1; } }
+    .sc-s1 .sc-blue  { animation: sc-blue-1  11.5s linear infinite; }
+    .sc-s1 .sc-green { animation: sc-green-1 11.5s linear infinite; }
+    .sc-s1 .sc-dot   { animation: sc-pulse-1 11.5s ease-in-out infinite; }
+    .sc-s2 .sc-blue  { animation: sc-blue-2  11.5s linear infinite; }
+    .sc-s2 .sc-green { animation: sc-green-2 11.5s linear infinite; }
+    .sc-s2 .sc-dot   { animation: sc-pulse-2 11.5s ease-in-out infinite; }
+    .sc-s3 .sc-blue  { animation: sc-blue-3  11.5s linear infinite; }
+    .sc-s3 .sc-green { animation: sc-green-3 11.5s linear infinite; }
+    .sc-s3 .sc-dot   { animation: sc-pulse-3 11.5s ease-in-out infinite; }
   }
 
+  @keyframes sc-cursor {
+    0%{transform:translate(0,0)}
+    1.85%{transform:translate(66px,0)}3.7%{transform:translate(132px,0)}
+    16.7%{transform:translate(198px,0)}18.55%{transform:translate(264px,0)}
+    20.4%{transform:translate(330px,0)}22.25%{transform:translate(396px,0)}
+    24.1%{transform:translate(0,66px)}25.95%{transform:translate(66px,66px)}
+    27.8%{transform:translate(132px,66px)}40.8%{transform:translate(198px,66px)}
+    42.65%{transform:translate(264px,66px)}44.5%{transform:translate(330px,66px)}
+    46.35%{transform:translate(396px,66px)}48.2%{transform:translate(0,132px)}
+    50.05%{transform:translate(66px,132px)}51.9%{transform:translate(132px,132px)}
+    64.9%{transform:translate(198px,132px)}66.75%{transform:translate(264px,132px)}
+    68.6%{transform:translate(330px,132px)}70.45%{transform:translate(396px,132px)}
+    72.3%{transform:translate(0,198px)}74.15%{transform:translate(66px,198px)}
+    76%{transform:translate(132px,198px)}77.85%{transform:translate(198px,198px)}
+    79.7%{transform:translate(264px,198px)}81.55%{transform:translate(330px,198px)}
+    83.4%{transform:translate(396px,198px)}
+  }
+
+  @keyframes sc-blue-1  { 0%, 16.7%  { opacity: 1; } 16.71%, 100% { opacity: 0; } }
+  @keyframes sc-green-1 { 0%, 16.7%  { opacity: 0; } 16.71%, 100% { opacity: 1; } }
+  @keyframes sc-pulse-1 { 0%, 3.7% { transform: scale(1); } 10% { transform: scale(1.6); } 16.7%, 100% { transform: scale(1); } }
+
+  @keyframes sc-blue-2  { 0%, 40.8%  { opacity: 1; } 40.81%, 100% { opacity: 0; } }
+  @keyframes sc-green-2 { 0%, 40.8%  { opacity: 0; } 40.81%, 100% { opacity: 1; } }
+  @keyframes sc-pulse-2 { 0%, 27.8% { transform: scale(1); } 34% { transform: scale(1.6); } 40.8%, 100% { transform: scale(1); } }
+
+  @keyframes sc-blue-3  { 0%, 64.9%  { opacity: 1; } 64.91%, 100% { opacity: 0; } }
+  @keyframes sc-green-3 { 0%, 64.9%  { opacity: 0; } 64.91%, 100% { opacity: 1; } }
+  @keyframes sc-pulse-3 { 0%, 51.9% { transform: scale(1); } 58% { transform: scale(1.6); } 64.9%, 100% { transform: scale(1); } }
+
   @media (prefers-reduced-motion: reduce) {
-    .sc-pill-text.sc-p1 { opacity: 0; }
-    .sc-pill-text.sc-p4 { opacity: 1; }
-    .sc-blue  { opacity: 0; }
+    .sc-cursor { display: none; }
+    .sc-blue { opacity: 0; }
     .sc-green { opacity: 1; }
   }
 </style>

--- a/src/components/visuals/ScheduleClock.astro
+++ b/src/components/visuals/ScheduleClock.astro
@@ -70,6 +70,10 @@ const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
       ))}
     </g>
 
+    <g class="sc-today" aria-hidden="true">
+      <rect class="fill-dark-charcoal" x="22" y="58" width="40" height="14" rx="7" />
+      <text class="sc-today-text fill-white" x="42" y="68">TODAY</text>
+    </g>
     <rect class="sc-cursor stroke-dark-charcoal" x="13" y="70" width="58" height="58" rx="10" fill="none" stroke-width="2" />
   </svg>
 </div>
@@ -100,21 +104,23 @@ const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
   .sc-green { opacity: 0; }
   .sc-dot { transform-box: fill-box; transform-origin: center; }
   .sc-cursor { opacity: 0.9; }
+  .sc-today-text { font-size: 8px; font-weight: 700; text-anchor: middle; letter-spacing: 0.08em; }
 
-  /* 11.5 s loop. Cursor walks 28 cells: 25 short hops (~0.21 s) + 3 transfer
-     stops (~1.5 s each) + 1.5 s "all-done" hold before snapping back. */
+  /* 22 s loop. Cursor walks 28 cells: 25 short hops (~0.4 s) + 3 transfer
+     stops (~3 s each) + 3 s "all-done" hold before snapping back. */
   @media (prefers-reduced-motion: no-preference) {
-    .sc-cursor { animation: sc-cursor 11.5s steps(1, end) infinite; }
+    .sc-cursor { animation: sc-cursor 22s steps(1, end) infinite; }
+    .sc-today  { animation: sc-cursor 22s steps(1, end) infinite; }
 
-    .sc-s1 .sc-blue  { animation: sc-blue-1  11.5s linear infinite; }
-    .sc-s1 .sc-green { animation: sc-green-1 11.5s linear infinite; }
-    .sc-s1 .sc-dot   { animation: sc-pulse-1 11.5s ease-in-out infinite; }
-    .sc-s2 .sc-blue  { animation: sc-blue-2  11.5s linear infinite; }
-    .sc-s2 .sc-green { animation: sc-green-2 11.5s linear infinite; }
-    .sc-s2 .sc-dot   { animation: sc-pulse-2 11.5s ease-in-out infinite; }
-    .sc-s3 .sc-blue  { animation: sc-blue-3  11.5s linear infinite; }
-    .sc-s3 .sc-green { animation: sc-green-3 11.5s linear infinite; }
-    .sc-s3 .sc-dot   { animation: sc-pulse-3 11.5s ease-in-out infinite; }
+    .sc-s1 .sc-blue  { animation: sc-blue-1  22s linear infinite; }
+    .sc-s1 .sc-green { animation: sc-green-1 22s linear infinite; }
+    .sc-s1 .sc-dot   { animation: sc-pulse-1 22s ease-in-out infinite; }
+    .sc-s2 .sc-blue  { animation: sc-blue-2  22s linear infinite; }
+    .sc-s2 .sc-green { animation: sc-green-2 22s linear infinite; }
+    .sc-s2 .sc-dot   { animation: sc-pulse-2 22s ease-in-out infinite; }
+    .sc-s3 .sc-blue  { animation: sc-blue-3  22s linear infinite; }
+    .sc-s3 .sc-green { animation: sc-green-3 22s linear infinite; }
+    .sc-s3 .sc-dot   { animation: sc-pulse-3 22s ease-in-out infinite; }
   }
 
   @keyframes sc-cursor {
@@ -148,7 +154,7 @@ const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
   @keyframes sc-pulse-3 { 0%, 51.9% { transform: scale(1); } 58% { transform: scale(1.6); } 64.9%, 100% { transform: scale(1); } }
 
   @media (prefers-reduced-motion: reduce) {
-    .sc-cursor { display: none; }
+    .sc-cursor, .sc-today { display: none; }
     .sc-blue { opacity: 0; }
     .sc-green { opacity: 1; }
   }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -122,8 +122,8 @@
       "viewFinalReport": "View final report"
     },
     "scheduleClock": {
-      "alt": "A weekly calendar with a recurring backup running every Wednesday and a countdown to the next run.",
-      "nextRun": "Next run · in"
+      "alt": "A weekly calendar with three scheduled backups on Wednesdays — each turns from blue to green as Today advances past it.",
+      "today": "Today"
     }
   },
   "guides": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -120,6 +120,10 @@
       "file4": "team-photo.heic",
       "file5": "marketing-assets/",
       "viewFinalReport": "View final report"
+    },
+    "scheduleClock": {
+      "alt": "A weekly calendar with a recurring backup running every Wednesday and a countdown to the next run.",
+      "nextRun": "Next run · in"
     }
   },
   "guides": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -122,8 +122,7 @@
       "viewFinalReport": "View final report"
     },
     "scheduleClock": {
-      "alt": "A weekly calendar with three scheduled backups on Wednesdays — each turns from blue to green as Today advances past it.",
-      "today": "Today"
+      "alt": "A monthly calendar with a Today cursor walking day by day; on each scheduled Wednesday it pauses to run the backup, the marker turns green, and the cursor moves on."
     }
   },
   "guides": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -122,8 +122,8 @@
       "viewFinalReport": "View final report"
     },
     "scheduleClock": {
-      "alt": "A weekly calendar with a recurring backup running every Wednesday and a countdown to the next run.",
-      "nextRun": "Next run · in"
+      "alt": "A weekly calendar with three scheduled backups on Wednesdays — each turns from blue to green as Today advances past it.",
+      "today": "Today"
     }
   },
   "guides": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -120,6 +120,10 @@
       "file4": "team-photo.heic",
       "file5": "marketing-assets/",
       "viewFinalReport": "View final report"
+    },
+    "scheduleClock": {
+      "alt": "A weekly calendar with a recurring backup running every Wednesday and a countdown to the next run.",
+      "nextRun": "Next run · in"
     }
   },
   "guides": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -122,8 +122,7 @@
       "viewFinalReport": "View final report"
     },
     "scheduleClock": {
-      "alt": "A weekly calendar with three scheduled backups on Wednesdays — each turns from blue to green as Today advances past it.",
-      "today": "Today"
+      "alt": "A monthly calendar with a Today cursor walking day by day; on each scheduled Wednesday it pauses to run the backup, the marker turns green, and the cursor moves on."
     }
   },
   "guides": {

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -8,10 +8,12 @@ import WaitlistForm from '../../../components/sections/WaitlistForm.astro';
 import StickyWaitlistBar from '../../../components/sections/StickyWaitlistBar.astro';
 import ProviderArc from '../../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../../components/visuals/MigrationChecklist.astro';
+import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
   'cloud-to-cloud-transfer': ProviderArc,
   'business-cloud-migration': MigrationChecklist,
+  'scheduled-cloud-backup': ScheduleClock,
 };
 
 export async function getStaticPaths() {

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -8,10 +8,12 @@ import WaitlistForm from '../../components/sections/WaitlistForm.astro';
 import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro';
 import ProviderArc from '../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../components/visuals/MigrationChecklist.astro';
+import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
   'cloud-to-cloud-transfer': ProviderArc,
   'business-cloud-migration': MigrationChecklist,
+  'scheduled-cloud-backup': ScheduleClock,
 };
 
 export async function getStaticPaths() {


### PR DESCRIPTION
## Summary

Adds `ScheduleClock.astro`, the Phase B hero visual for `/use-cases/scheduled-cloud-backup`. A 480×480 SVG calendar (7×4 grid) with three Wednesdays pulsing sequentially over a 5 s loop and a cosmetic "Next run · in 12h 04m" pill that cycles three pre-rendered states. Pure SVG, zero JS, zero props, Tailwind tokens only. Mounted on the slug visual map for both `/use-cases/[slug]` and `/pt-br/use-cases/[slug]`.

## Visual spec compliance

- 480×480 SVG, ~4.7 KB component file (well under the 6 KB inline-SVG budget).
- Pure SVG + scoped `<style>`. Zero client JS. Zero props.
- Brand-blue stays interactive — used only on the pulse + the pill (which read as the page's "next scheduled action").
- All colours via Tailwind tokens (`fill-baby-blue`, `fill-brand-blue`, `fill-warm-gray`, `fill-slate-gray`, `stroke-divider`, `stroke-brand-blue`). No inline hex.
- `prefers-reduced-motion: reduce` renders a static end state — all three highlights visible, pill locked to its first state, no swap.
- i18n: `visuals.scheduleClock.{alt,nextRun}` added to `en.json`, mirrored with English placeholder in `pt-br.json`. Phase C (#112) will translate.

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings, 1 pre-existing hint in `RevealOnScroll.astro` unrelated to this change.
- [x] `npm test` — 41 passed (4 files).
- [x] `npm run build` — clean; both `/use-cases/scheduled-cloud-backup/index.html` and the pt-BR mirror render the visual; the other use-case slugs continue to render their own visuals (or none).
- [x] `npm run dev` — HTTP 200 on en + pt-BR pages; the rendered HTML contains the `schedule-clock` wrapper, the alt label, the three `sc-pill-text` states, and the three `sc-hl-*` highlight groups.
- [x] **Real-browser pass at `lg` / `md` / `sm` and reduced-motion was not performed in this session** — this needs a human eye on the animation loop and the responsive negative-margin tuning before merge.

Closes #106