### PR TITLE
fix(hero): prevent visual overflow at 1024px viewport

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -39,7 +39,7 @@ const subheadingClass =
 
 const hasVisual = Astro.slots.has('visual');
 const gridClass = hasVisual
-  ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,760px)_minmax(0,1fr)] gap-12 items-center'
+  ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)] xl:grid-cols-[minmax(0,760px)_minmax(0,1fr)] gap-12 items-center'
   : 'grid grid-cols-1 gap-12 items-center';
 ---
 

--- a/src/components/visuals/PricingCurves.astro
+++ b/src/components/visuals/PricingCurves.astro
@@ -20,9 +20,9 @@ const privateStatus = t('visuals.pricingCurves.privateStatus');
   >
     <defs>
       <g id="pc-pkt">
-        <rect x="-14" y="-9" width="28" height="18" rx="4" class="fill-white stroke-divider" stroke-width="1" />
-        <line x1="-7" y1="-3" x2="6" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
-        <line x1="-7" y1="3"  x2="2" y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <rect x="-14" y="-9" width="28" height="18" rx="4" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-7" y1="-3" x2="6" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-7" y1="3"  x2="2" y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
       </g>
       <g id="pc-dollar">
         <circle r="12" class="fill-success-bg" />
@@ -249,8 +249,9 @@ const privateStatus = t('visuals.pricingCurves.privateStatus');
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .ring-cloud,
     .ring-private { opacity: 1; }
-    .card-cloud   { opacity: 0.5; }
+    .card-cloud,
     .card-private { opacity: 1; }
     .files-cloud,
     .files-private,
@@ -259,7 +260,7 @@ const privateStatus = t('visuals.pricingCurves.privateStatus');
     .dollar-2,
     .dollar-3,
     .dollar-4 {
-      opacity: 0;
+      opacity: 1;
     }
   }
 </style>

--- a/src/components/visuals/ProviderArc.astro
+++ b/src/components/visuals/ProviderArc.astro
@@ -43,19 +43,19 @@ const altLabel = t('visuals.providerArc.alt');
 
     <g class="file-pills" aria-hidden="true">
       <g class="file-pill" style="--pill-delay: 0s;">
-        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-divider" stroke-width="1" />
-        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
-        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
       </g>
       <g class="file-pill" style="--pill-delay: 0.45s;">
-        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-divider" stroke-width="1" />
-        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
-        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
       </g>
       <g class="file-pill" style="--pill-delay: 0.9s;">
-        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-divider" stroke-width="1" />
-        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
-        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-divider" />
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3"  x2="4"  y2="3"  stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
       </g>
     </g>
   </svg>


### PR DESCRIPTION
Closes #123

## Approach

**Approach 2** (asymmetric column widths). Single edit to `src/components/sections/Hero.astro`; no per-visual changes. Selected per the issue's default recommendation — preserves the two-column hero on every laptop while keeping all `src/components/visuals/*.astro` `min-width: 320px` assumptions intact.

```
- lg:grid-cols-[minmax(0,760px)_minmax(0,1fr)]
+ lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)]
+ xl:grid-cols-[minmax(0,760px)_minmax(0,1fr)]
```

## Math

`.container-wide` is `max-width: 1440` with `padding-inline: 24px` (mobile) / `40px` (≥1024).

| Viewport | Container content | Headline track | Gap | Visual track (1fr) | Visual min-width 320 fits? |
|---|---|---|---|---|---|
| 1024 (lg)  | 944  | 560 | 48 | 336 | ✓ +16px |
| 1100 (lg)  | 1020 | 560 | 48 | 412 | ✓ |
| 1200 (lg)  | 1120 | 560 | 48 | 512 | ✓ |
| 1280 (xl)  | 1200 | 760 | 48 | 392 | ✓ |
| 1440 (xl)  | 1360 | 760 | 48 | 552 | ✓ |

Below `lg` (≤1023) the grid stays `grid-cols-1` — single-column stack is unchanged.

## Diagnostic snapshot

Not performed in a real browser — visual verification could not be run from the implementation environment. The math above demonstrates the overflow is removed at every width in the diagnostic matrix; the issue's analytical breakdown of the bug (760 + 48 + 320 = 1128 against 944px content area at 1024) is consistent with what was observed in source.

**Reviewer must run the matrix in a real browser** at 1024 / 1100 / 1200 / 1280 / 1440 px on every shipped Phase-B page (`/use-cases/cloud-to-cloud-transfer`, `/use-cases/scheduled-cloud-backup`, plus pt-BR mirrors) before merging:

- [ ] No horizontal scrollbar at any width on any page.
- [ ] Hero visual stays inside the container at every width.
- [ ] Headline doesn't wrap awkwardly (orphan word) at the new 560px column.
- [ ] Animations still play correctly inside the smaller column.
- [ ] `prefers-reduced-motion: reduce` still renders a static end-state.

## Container audit

`.container-wide` (`src/styles/global.css:30`) already applies 24px padding mobile / 40px ≥1024 — matches DESIGN.md. No changes needed.

---

## Bundled out-of-scope changes (second commit)

Approved by repo owner during review; bundled here to avoid a separate PR for trivial visual polish:

1. **`src/components/visuals/PricingCurves.astro`** — file packet (`#pc-pkt`) recolored from `stroke-divider` to `stroke-brand-blue` (rect outline + inner lines, white fill preserved). Matches `PrivateRunnerPath.astro`'s `#prp-pkt` so "in-flight file" iconography is consistent across Phase-B visuals.
2. **`src/components/visuals/ProviderArc.astro`** — same treatment applied to the three rounded file pills traveling along the arc.
3. **`src/components/visuals/PricingCurves.astro`** (`prefers-reduced-motion: reduce` block) — static fallback now shows the cloud runner's accumulating dollar icons alongside the private runner's $6 tag, instead of only the private end-state. Both cards rendered at full opacity (the cloud card was at 0.5, which would have dimmed the dollars).

Stroke widths kept at their original values (`1` rect outline, `1.5` inner lines) — color-only change.

## Out of scope (still)

Per the issue: no new visuals, no guide-template edits (#111 / B½), homepage `TransferPlanner` is unaffected (does not use the shared Hero two-column slot).

## Verification

- `npm run lint` — 0 errors (1 pre-existing ts(6196) hint in `RevealOnScroll.astro`, untouched).
- `npm test` — 41/41 passing.
- `npm run build` — clean.
- Real-browser pass: **not performed** — must be done by reviewer.