### PR TITLE
feat(guides): centered blog-post template + /guides index + Resources footer column

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -11,6 +11,7 @@
 - `bg-white` — primary canvas
 - `bg-soft-gray` (#F1F4F7) — secondary section background
 - `bg-warm-gray` (#F7F8FA) — flat card surface
+- `bg-reading-paper` (#F6F5F1) — long-form reading surface (guide articles only); near-neutral off-white
 - `bg-baby-blue` (#E8F3FF) — info highlight
 - `bg-near-black` (#1C1E21) — dark immersive sections
 - `bg-brand-blue` / `hover:bg-brand-blue-hover` / `active:bg-brand-blue-pressed` — primary CTA only

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,6 +31,7 @@ The visual hierarchy is ruthlessly simple. Visuals do the heavy lifting, support
 - **White** (`#FFFFFF`): Primary page canvas, nav bar background, card surfaces
 - **Soft Gray** (`#F1F4F7`): Secondary background for content sections
 - **Warm Gray** (`#F7F8FA`): Flat card background, subtle surface differentiation
+- **Reading Paper** (`#F6F5F1`): Long-form reading surface (guide articles). Near-neutral off-white — distinct from pure white, eases eye strain on extended reading. Used **only** for guide article wrappers.
 - **Baby Blue** (`#E8F3FF`): Highlight background, subtle blue tint for informational areas
 - **Near Black** (`#1C1E21`): Dark section backgrounds, immersive product showcase areas
 - **Overlay** (`rgba(0, 0, 0, 0.6)`): Modal/lightbox backdrop

--- a/src/components/guides/BackToTop.astro
+++ b/src/components/guides/BackToTop.astro
@@ -1,0 +1,51 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+---
+
+<button
+  type="button"
+  data-back-to-top
+  aria-label={t('guides.meta.backToTop')}
+  class="fixed bottom-6 right-6 z-40 h-12 w-12 rounded-pill bg-dark-charcoal text-white shadow-card-elevated flex items-center justify-center opacity-0 pointer-events-none translate-y-2 transition-all duration-300 ease-out hover:bg-near-black focus-visible:outline-none"
+>
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <polyline points="18 15 12 9 6 15" />
+  </svg>
+</button>
+
+<style>
+  [data-back-to-top].is-visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+</style>
+
+<script>
+  const btn = document.querySelector<HTMLButtonElement>('[data-back-to-top]');
+  if (btn) {
+    let ticking = false;
+    const update = () => {
+      btn.classList.toggle('is-visible', window.scrollY > 480);
+      ticking = false;
+    };
+    window.addEventListener(
+      'scroll',
+      () => {
+        if (!ticking) {
+          window.requestAnimationFrame(update);
+          ticking = true;
+        }
+      },
+      { passive: true },
+    );
+    btn.addEventListener('click', () => {
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+    });
+    update();
+  }
+</script>

--- a/src/components/guides/Caption.astro
+++ b/src/components/guides/Caption.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: extra = '' } = Astro.props as Props;
+---
+
+<figcaption class={`text-caption text-slate-gray italic mt-3 ${extra}`}>
+  <slot />
+</figcaption>

--- a/src/components/guides/Note.astro
+++ b/src/components/guides/Note.astro
@@ -1,0 +1,29 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+interface Props {
+  label?: string;
+  class?: string;
+}
+
+const { label, class: extra = '' } = Astro.props as Props;
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const resolvedLabel = label ?? t('guides.callout.note');
+---
+
+<aside class={`bg-baby-blue rounded-card px-6 py-5 my-8 text-body text-dark-charcoal ${extra}`}>
+  <span class="block text-caption font-medium uppercase tracking-wide text-brand-blue mb-2">{resolvedLabel}</span>
+  <div class="prose-syncologic-note">
+    <slot />
+  </div>
+</aside>
+
+<style>
+  .prose-syncologic-note :global(p) {
+    margin: 0;
+  }
+  .prose-syncologic-note :global(p + p) {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/components/guides/TableOfContents.astro
+++ b/src/components/guides/TableOfContents.astro
@@ -1,0 +1,81 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props as Props;
+const items = headings.filter((h) => h.depth === 2);
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+---
+
+{items.length > 1 && (
+  <nav class="guide-toc text-caption" aria-labelledby="guide-toc-title">
+    <p id="guide-toc-title" class="text-caption font-medium text-dark-charcoal mb-3">{t('guides.meta.tableOfContents')}</p>
+    <ul class="space-y-1 border-l border-divider">
+      {items.map((h) => (
+        <li>
+          <a
+            href={`#${h.slug}`}
+            data-toc-link
+            data-toc-target={h.slug}
+            class="guide-toc__link block py-1.5 pl-4 -ml-px border-l-2 border-transparent text-slate-gray hover:text-dark-charcoal transition-colors"
+          >
+            {h.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}
+
+<style>
+  .guide-toc__link.is-active {
+    color: theme('colors.dark-charcoal');
+    border-color: theme('colors.brand-blue.DEFAULT');
+    font-weight: 500;
+  }
+</style>
+
+<script>
+  const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]'));
+  if (links.length > 0) {
+    const targets = links
+      .map((link) => {
+        const id = link.dataset.tocTarget;
+        return id ? document.getElementById(id) : null;
+      })
+      .filter((el): el is HTMLElement => Boolean(el));
+
+    const setActive = (slug: string) => {
+      for (const link of links) {
+        link.classList.toggle('is-active', link.dataset.tocTarget === slug);
+      }
+    };
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const visible = entries.filter((e) => e.isIntersecting);
+          if (visible.length > 0) {
+            visible.sort((a, b) => a.target.getBoundingClientRect().top - b.target.getBoundingClientRect().top);
+            const id = visible[0]!.target.id;
+            if (id) setActive(id);
+          }
+        },
+        { rootMargin: '-80px 0px -65% 0px', threshold: 0 },
+      );
+      for (const target of targets) observer.observe(target);
+    }
+
+    if (targets.length > 0 && targets[0]) setActive(targets[0].id);
+  }
+</script>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -28,9 +28,10 @@ const pathname = Astro.url.pathname;
       </div>
 
       <div>
-        <h3 class="text-caption font-medium uppercase tracking-wide text-slate-gray mb-3">{t('footer.resources')}</h3>
+        <h3 class="text-caption font-medium uppercase tracking-wide text-slate-gray mb-3">{t('footer.resourcesColumn.title')}</h3>
         <ul class="space-y-2 text-caption">
-          <li><a href={localizedPath(locale, '/use-cases/cloud-to-cloud-transfer')} class="hover:underline">{t('nav.useCases')}</a></li>
+          <li><a href={localizedPath(locale, '/guides')} class="hover:underline">{t('footer.resourcesColumn.guides')}</a></li>
+          <li><a href={localizedPath(locale, '/use-cases/cloud-to-cloud-transfer')} class="hover:underline">{t('footer.resourcesColumn.useCases')}</a></li>
         </ul>
       </div>
 

--- a/src/components/layout/Layout.astro
+++ b/src/components/layout/Layout.astro
@@ -46,7 +46,7 @@ const og = ogImage ?? `${siteUrl}/og/default-${locale}.png`;
   </head>
   <body>
     <slot name="nav" />
-    <main id="main">
+    <main id="main" class="pt-16">
       <slot />
     </main>
     <slot name="footer" />

--- a/src/components/layout/Nav.astro
+++ b/src/components/layout/Nav.astro
@@ -15,10 +15,14 @@ const useCases = [
 
 const otherLocale = locale === 'en' ? 'pt-br' : 'en';
 const otherLocalePath = localizedPath(otherLocale, path);
+
+const isGuide = path === '/guides' || path.startsWith('/guides/');
+const positionClass = isGuide ? 'absolute' : 'fixed';
+const waitlistHref = isGuide ? `${localizedPath(locale, '/')}#waitlist` : '#waitlist';
 ---
 
 <header
-  class="sticky top-0 z-50 w-full bg-white/80 backdrop-blur border-b border-[rgba(0,0,0,0.06)]"
+  class={`${positionClass} top-0 left-0 right-0 z-50 w-full bg-white/85 backdrop-blur border-b border-[rgba(0,0,0,0.06)]`}
   data-locale={locale}
 >
   <nav class="container-wide flex items-center justify-between h-16">
@@ -59,7 +63,7 @@ const otherLocalePath = localizedPath(otherLocale, path);
       >
         {otherLocale === 'pt-br' ? 'PT' : 'EN'}
       </a>
-      <Button href="#waitlist" variant="primary" size="sm">{t('nav.joinWaitlist')}</Button>
+      <Button href={waitlistHref} variant="primary" size="sm">{t('nav.joinWaitlist')}</Button>
     </div>
   </nav>
 </header>

--- a/src/components/sections/GuideCrossLinks.astro
+++ b/src/components/sections/GuideCrossLinks.astro
@@ -1,0 +1,49 @@
+---
+import { getCollection } from 'astro:content';
+import { getLocaleFromUrl, getT, localizedPath, type Locale } from '../../i18n/utils';
+import { readingTimeMinutes } from '../../lib/reading-time';
+
+interface Props {
+  slugs: string[];
+}
+
+const { slugs } = Astro.props as Props;
+const locale: Locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+
+const entries = await getCollection('guides', (e) => e.data.locale === locale);
+const prefix = locale === 'en' ? 'en/' : 'pt-br/';
+const bySlug = new Map(entries.map((e) => [e.slug.replace(prefix, ''), e]));
+
+const guides = slugs
+  .map((s) => bySlug.get(s))
+  .filter((e): e is NonNullable<typeof e> => Boolean(e))
+  .map((e) => ({
+    slug: e.slug.replace(prefix, ''),
+    title: e.data.title,
+    description: e.data.description,
+    eyebrow: e.data.eyebrow,
+    readingTime: readingTimeMinutes(e.body ?? ''),
+  }));
+---
+
+{guides.length > 0 && (
+  <section class="bg-warm-gray py-section">
+    <div class="max-w-[960px] mx-auto px-6">
+      <h2 class="text-h1 font-medium text-dark-charcoal mb-8">{t('useCases.furtherReading')}</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {guides.map((g) => (
+          <a
+            href={localizedPath(locale, `/guides/${g.slug}`)}
+            class="block bg-white rounded-card p-6 hover:shadow-card transition-shadow"
+          >
+            <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{g.eyebrow}</span>
+            <h3 class="text-h3 font-bold text-dark-charcoal mt-2">{g.title}</h3>
+            <p class="text-body text-slate-gray mt-3 line-clamp-3">{g.description}</p>
+            <p class="text-caption text-slate-gray mt-4">{t('guides.meta.readingTime', { minutes: g.readingTime })}</p>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+)}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -35,7 +35,8 @@ const guideSchema = z.object({
   primaryCta: ctaSchema,
   waitlistSegment: waitlistSegmentEnum.optional(),
   publishedAt: z.coerce.date(),
-  updatedAt: z.coerce.date().optional(),
+  updatedAt: z.coerce.date(),
+  relatedSlugs: z.array(z.string()).default([]),
 });
 
 export const collections = {

--- a/src/content/guides/en/move-files-between-clouds-without-downloading.mdx
+++ b/src/content/guides/en/move-files-between-clouds-without-downloading.mdx
@@ -9,6 +9,9 @@ primaryCta:
   label: "Join the waitlist"
   href: "#waitlist"
 publishedAt: 2026-04-30
+updatedAt: 2026-04-30
+relatedSlugs:
+  - transfer-google-drive-to-onedrive
 ---
 
 You have a folder in Google Drive, Dropbox, or OneDrive. You want it in another cloud. The obvious path — download everything, then re-upload — is also the slowest, most fragile one. This guide walks through the alternatives honestly: what works for small jobs, where each approach breaks, and what to reach for when none of them are enough.

--- a/src/content/guides/en/transfer-google-drive-to-onedrive.mdx
+++ b/src/content/guides/en/transfer-google-drive-to-onedrive.mdx
@@ -10,6 +10,9 @@ primaryCta:
   href: "#waitlist"
 waitlistSegment: one_time_transfer
 publishedAt: 2026-05-01
+updatedAt: 2026-05-01
+relatedSlugs:
+  - move-files-between-clouds-without-downloading
 ---
 
 You have files in Google Drive. You want them in OneDrive. Maybe you're switching to Microsoft 365, consolidating a company onto a single workspace, or just tired of paying for two cloud subscriptions. Either way, the path between the two clouds is messier than it should be — and the official tools that used to bridge them are mostly gone.

--- a/src/content/guides/pt-br/move-files-between-clouds-without-downloading.mdx
+++ b/src/content/guides/pt-br/move-files-between-clouds-without-downloading.mdx
@@ -9,6 +9,9 @@ primaryCta:
   label: "Join the waitlist"
   href: "#waitlist"
 publishedAt: 2026-04-30
+updatedAt: 2026-04-30
+relatedSlugs:
+  - transfer-google-drive-to-onedrive
 ---
 
 You have a folder in Google Drive, Dropbox, or OneDrive. You want it in another cloud. The obvious path — download everything, then re-upload — is also the slowest, most fragile one. This guide walks through the alternatives honestly: what works for small jobs, where each approach breaks, and what to reach for when none of them are enough.

--- a/src/content/guides/pt-br/transfer-google-drive-to-onedrive.mdx
+++ b/src/content/guides/pt-br/transfer-google-drive-to-onedrive.mdx
@@ -10,6 +10,9 @@ primaryCta:
   href: "#waitlist"
 waitlistSegment: one_time_transfer
 publishedAt: 2026-05-01
+updatedAt: 2026-05-01
+relatedSlugs:
+  - move-files-between-clouds-without-downloading
 ---
 
 You have files in Google Drive. You want them in OneDrive. Maybe you're switching to Microsoft 365, consolidating a company onto a single workspace, or just tired of paying for two cloud subscriptions. Either way, the path between the two clouds is messier than it should be — and the official tools that used to bridge them are mostly gone.

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -29,7 +29,12 @@
     "product": "Product",
     "resources": "Resources",
     "company": "Company",
-    "copyright": "© {year} Syncologic"
+    "copyright": "© {year} Syncologic",
+    "resourcesColumn": {
+      "title": "Resources",
+      "guides": "Guides",
+      "useCases": "Use cases"
+    }
   },
   "language": {
     "label": "Language",
@@ -99,7 +104,8 @@
   },
   "useCases": {
     "indexTitle": "Use cases",
-    "indexDescription": "Pick the workflow that matches what you're trying to do."
+    "indexDescription": "Pick the workflow that matches what you're trying to do.",
+    "furtherReading": "Further reading"
   },
   "visuals": {
     "providerArc": {
@@ -157,7 +163,30 @@
   },
   "guides": {
     "indexTitle": "Guides",
-    "indexDescription": "How to move files between cloud providers without downloading them first."
+    "indexDescription": "How to move files between cloud providers without downloading them first.",
+    "index": {
+      "title": "Guides — Syncologic",
+      "description": "Practical guides for moving files between cloud providers — without downloading them first.",
+      "eyebrow": "Guides",
+      "headline": "Guides for moving files between clouds.",
+      "subheading": "Honest answers first. Each guide explains the options, the trade-offs, and where Syncologic fits — only after the search query is answered."
+    },
+    "meta": {
+      "readingTime": "{minutes} min read",
+      "updated": "Updated",
+      "readNext": "Read next",
+      "tableOfContents": "On this page",
+      "backToTop": "Back to top"
+    },
+    "callout": {
+      "note": "Note"
+    },
+    "cta": {
+      "title": "Want this without writing the glue?",
+      "body": "Syncologic moves folders directly between providers — preview, run, and report. Pick the use case that matches your job and join the waitlist.",
+      "primary": "Pick your use case",
+      "secondary": "Back to home"
+    }
   },
   "faq": {
     "title": "Common questions"

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -29,7 +29,12 @@
     "product": "Product",
     "resources": "Resources",
     "company": "Company",
-    "copyright": "© {year} Syncologic"
+    "copyright": "© {year} Syncologic",
+    "resourcesColumn": {
+      "title": "Resources",
+      "guides": "Guides",
+      "useCases": "Use cases"
+    }
   },
   "language": {
     "label": "Language",
@@ -99,7 +104,8 @@
   },
   "useCases": {
     "indexTitle": "Use cases",
-    "indexDescription": "Pick the workflow that matches what you're trying to do."
+    "indexDescription": "Pick the workflow that matches what you're trying to do.",
+    "furtherReading": "Further reading"
   },
   "visuals": {
     "providerArc": {
@@ -157,7 +163,30 @@
   },
   "guides": {
     "indexTitle": "Guides",
-    "indexDescription": "How to move files between cloud providers without downloading them first."
+    "indexDescription": "How to move files between cloud providers without downloading them first.",
+    "index": {
+      "title": "Guides — Syncologic",
+      "description": "Practical guides for moving files between cloud providers — without downloading them first.",
+      "eyebrow": "Guides",
+      "headline": "Guides for moving files between clouds.",
+      "subheading": "Honest answers first. Each guide explains the options, the trade-offs, and where Syncologic fits — only after the search query is answered."
+    },
+    "meta": {
+      "readingTime": "{minutes} min read",
+      "updated": "Updated",
+      "readNext": "Read next",
+      "tableOfContents": "On this page",
+      "backToTop": "Back to top"
+    },
+    "callout": {
+      "note": "Note"
+    },
+    "cta": {
+      "title": "Want this without writing the glue?",
+      "body": "Syncologic moves folders directly between providers — preview, run, and report. Pick the use case that matches your job and join the waitlist.",
+      "primary": "Pick your use case",
+      "secondary": "Back to home"
+    }
   },
   "faq": {
     "title": "Common questions"

--- a/src/lib/__tests__/reading-time.test.ts
+++ b/src/lib/__tests__/reading-time.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readingTimeMinutes } from '../reading-time';
+
+describe('readingTimeMinutes', () => {
+  it('returns 1 for empty input', () => {
+    expect(readingTimeMinutes('')).toBe(1);
+  });
+
+  it('returns 1 for very short input', () => {
+    expect(readingTimeMinutes('one two three')).toBe(1);
+  });
+
+  it('rounds up partial minutes', () => {
+    const words = Array.from({ length: 201 }, (_, i) => `w${i}`).join(' ');
+    expect(readingTimeMinutes(words)).toBe(2);
+  });
+
+  it('treats exactly 200 words as 1 minute', () => {
+    const words = Array.from({ length: 200 }, (_, i) => `w${i}`).join(' ');
+    expect(readingTimeMinutes(words)).toBe(1);
+  });
+
+  it('treats 400 words as 2 minutes', () => {
+    const words = Array.from({ length: 400 }, (_, i) => `w${i}`).join(' ');
+    expect(readingTimeMinutes(words)).toBe(2);
+  });
+
+  it('treats 401 words as 3 minutes', () => {
+    const words = Array.from({ length: 401 }, (_, i) => `w${i}`).join(' ');
+    expect(readingTimeMinutes(words)).toBe(3);
+  });
+
+  it('strips MDX frontmatter before counting', () => {
+    const body = '---\ntitle: foo\nlocale: en\n---\n\n' + Array.from({ length: 250 }, () => 'word').join(' ');
+    expect(readingTimeMinutes(body)).toBe(2);
+  });
+
+  it('strips fenced code blocks before counting', () => {
+    const body =
+      Array.from({ length: 100 }, () => 'word').join(' ') +
+      '\n\n```ts\n' +
+      Array.from({ length: 1000 }, () => 'noise').join(' ') +
+      '\n```\n';
+    expect(readingTimeMinutes(body)).toBe(1);
+  });
+
+  it('treats markdown punctuation as separators', () => {
+    expect(readingTimeMinutes('one,two.three;four')).toBe(1);
+  });
+
+  it('ignores HTML/JSX tags when counting', () => {
+    const body = '<Caption>note here</Caption> ' + Array.from({ length: 198 }, () => 'word').join(' ');
+    expect(readingTimeMinutes(body)).toBe(1);
+  });
+});

--- a/src/lib/reading-time.ts
+++ b/src/lib/reading-time.ts
@@ -1,0 +1,12 @@
+const WORDS_PER_MINUTE = 200;
+
+export function readingTimeMinutes(source: string): number {
+  const stripped = source
+    .replace(/^---\n[\s\S]*?\n---\n?/, '')
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/<[^>]+>/g, ' ');
+
+  const words = stripped.split(/[\s.,;:!?()[\]{}'"`–—]+/).filter(Boolean);
+  if (words.length === 0) return 1;
+  return Math.max(1, Math.ceil(words.length / WORDS_PER_MINUTE));
+}

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -3,35 +3,118 @@ import { getCollection } from 'astro:content';
 import Layout from '../../components/layout/Layout.astro';
 import Nav from '../../components/layout/Nav.astro';
 import Footer from '../../components/layout/Footer.astro';
-import Hero from '../../components/sections/Hero.astro';
-import WaitlistForm from '../../components/sections/WaitlistForm.astro';
-import StickyWaitlistBar from '../../components/sections/StickyWaitlistBar.astro';
+import Section from '../../components/ui/Section.astro';
+import Button from '../../components/ui/Button.astro';
+import Caption from '../../components/guides/Caption.astro';
+import Note from '../../components/guides/Note.astro';
+import TableOfContents from '../../components/guides/TableOfContents.astro';
+import BackToTop from '../../components/guides/BackToTop.astro';
+import ProviderArc from '../../components/visuals/ProviderArc.astro';
+import MigrationChecklist from '../../components/visuals/MigrationChecklist.astro';
+import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
+import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
+import { getT, localizedPath } from '../../i18n/utils';
+import { readingTimeMinutes } from '../../lib/reading-time';
 
 export async function getStaticPaths() {
   const entries = await getCollection('guides', (e) => e.data.locale === 'en');
-  return entries.map((entry) => ({
-    params: { slug: entry.slug.replace(/^en\//, '') },
-    props: { entry },
-  }));
+  const bySlug = new Map(entries.map((e) => [e.slug.replace(/^en\//, ''), e]));
+  return entries.map((entry) => {
+    const slug = entry.slug.replace(/^en\//, '');
+    const related = (entry.data.relatedSlugs ?? [])
+      .map((s) => bySlug.get(s))
+      .filter((e): e is NonNullable<typeof e> => Boolean(e))
+      .map((e) => ({
+        slug: e.slug.replace(/^en\//, ''),
+        title: e.data.title,
+        description: e.data.description,
+        eyebrow: e.data.eyebrow,
+        readingTime: readingTimeMinutes(e.body ?? ''),
+      }));
+    return { params: { slug }, props: { entry, related } };
+  });
 }
 
-const { entry } = Astro.props;
-const { Content } = await entry.render();
+const { entry, related } = Astro.props;
+const { Content, headings } = await entry.render();
 const ogImage = entry.data.ogImage ?? '/og/default-en.png';
+const t = getT('en');
+const minutes = readingTimeMinutes(entry.body ?? '');
+const updatedLabel = new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(entry.data.updatedAt);
+const updatedIso = entry.data.updatedAt.toISOString().slice(0, 10);
+const segmentHref = entry.data.waitlistSegment === 'business_migration'
+  ? '/use-cases/business-cloud-migration'
+  : '/use-cases/cloud-to-cloud-transfer';
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
   <Nav slot="nav" />
-  <Hero
-    eyebrow={entry.data.eyebrow}
-    headline={entry.data.headline}
-    subheading={entry.data.subheading}
-    primaryCta={entry.data.primaryCta}
-  />
-  <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content />
+
+  <article class="bg-reading-paper">
+    <div class="max-w-[1200px] mx-auto px-6 py-section-lg lg:grid lg:grid-cols-[220px_minmax(0,720px)_220px] lg:gap-10">
+      <aside class="hidden lg:block">
+        <div class="sticky top-24">
+          <TableOfContents headings={headings} />
+        </div>
+      </aside>
+
+      <div class="min-w-0">
+        <header class="mb-12">
+          <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{entry.data.eyebrow}</span>
+          <h1 class="text-h1 font-medium text-dark-charcoal mt-3 leading-tight">{entry.data.headline}</h1>
+          <p class="text-body text-slate-gray mt-5 leading-relaxed">{entry.data.subheading}</p>
+          <p class="text-caption text-slate-gray mt-6 flex flex-wrap gap-x-3 gap-y-1 items-center">
+            <span>{t('guides.meta.readingTime', { minutes })}</span>
+            <span aria-hidden="true">·</span>
+            <span>
+              {t('guides.meta.updated')}
+              {' '}
+              <time datetime={updatedIso}>{updatedLabel}</time>
+            </span>
+          </p>
+        </header>
+
+        <div class="prose-syncologic prose-syncologic--reading">
+          <Content components={{ ProviderArc, MigrationChecklist, ScheduleClock, PrivateRunnerPath, Caption, Note }} />
+        </div>
+      </div>
+
+      <div class="hidden lg:block" aria-hidden="true"></div>
+    </div>
   </article>
-  <WaitlistForm segmentHint={entry.data.waitlistSegment ?? null} />
+
+  <Section surface="soft" padding="md">
+    <div class="max-w-[720px] mx-auto text-center">
+      <h2 class="text-h2 font-light text-dark-charcoal">{t('guides.cta.title')}</h2>
+      <p class="text-body text-slate-gray mt-4 leading-relaxed">{t('guides.cta.body')}</p>
+      <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <Button href={localizedPath('en', segmentHref)} variant="primary" size="lg">{t('guides.cta.primary')}</Button>
+        <Button href={localizedPath('en', '/')} variant="secondary" size="lg">{t('guides.cta.secondary')}</Button>
+      </div>
+    </div>
+  </Section>
+
+  {related.length > 0 && (
+    <section class="bg-reading-paper py-section">
+      <div class="max-w-[960px] mx-auto px-6">
+        <h2 class="text-h1 font-medium text-dark-charcoal mb-8">{t('guides.meta.readNext')}</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {related.map((r) => (
+            <a
+              href={localizedPath('en', `/guides/${r.slug}`)}
+              class="block bg-white rounded-card p-6 hover:shadow-card transition-shadow"
+            >
+              <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{r.eyebrow}</span>
+              <h3 class="text-h3 font-bold text-dark-charcoal mt-2">{r.title}</h3>
+              <p class="text-body text-slate-gray mt-3 line-clamp-3">{r.description}</p>
+              <p class="text-caption text-slate-gray mt-4">{t('guides.meta.readingTime', { minutes: r.readingTime })}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <BackToTop />
   <Footer slot="footer" />
-  <StickyWaitlistBar />
 </Layout>

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../components/layout/Layout.astro';
+import Nav from '../../components/layout/Nav.astro';
+import Footer from '../../components/layout/Footer.astro';
+import { getT, localizedPath } from '../../i18n/utils';
+import { readingTimeMinutes } from '../../lib/reading-time';
+
+const t = getT('en');
+const entries = await getCollection('guides', (e) => e.data.locale === 'en');
+const guides = entries
+  .map((e) => ({
+    slug: e.slug.replace(/^en\//, ''),
+    title: e.data.title,
+    description: e.data.description,
+    eyebrow: e.data.eyebrow,
+    readingTime: readingTimeMinutes(e.body ?? ''),
+    updatedAt: e.data.updatedAt,
+    updatedIso: e.data.updatedAt.toISOString().slice(0, 10),
+    updatedLabel: new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(e.data.updatedAt),
+  }))
+  .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+const indexTitle = t('guides.index.title');
+const indexDescription = t('guides.index.description');
+---
+
+<Layout title={indexTitle} description={indexDescription}>
+  <Nav slot="nav" />
+
+  <article class="bg-reading-paper">
+    <div class="max-w-[960px] mx-auto px-6 py-section-lg">
+      <header class="max-w-[720px] mb-12">
+        <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{t('guides.index.eyebrow')}</span>
+        <h1 class="text-h1 font-medium text-dark-charcoal mt-3 leading-tight">{t('guides.index.headline')}</h1>
+        <p class="text-body text-slate-gray mt-5 leading-relaxed">{t('guides.index.subheading')}</p>
+      </header>
+
+      <ul class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {guides.map((g) => (
+          <li>
+            <a
+              href={localizedPath('en', `/guides/${g.slug}`)}
+              class="block bg-white rounded-card p-6 h-full hover:shadow-card transition-shadow"
+            >
+              <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{g.eyebrow}</span>
+              <h2 class="text-h3 font-bold text-dark-charcoal mt-2">{g.title}</h2>
+              <p class="text-body text-slate-gray mt-3 line-clamp-3">{g.description}</p>
+              <p class="text-caption text-slate-gray mt-4 flex flex-wrap gap-x-3 gap-y-1">
+                <span>{t('guides.meta.readingTime', { minutes: g.readingTime })}</span>
+                <span aria-hidden="true">·</span>
+                <span>
+                  {t('guides.meta.updated')}
+                  {' '}
+                  <time datetime={g.updatedIso}>{g.updatedLabel}</time>
+                </span>
+              </p>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </article>
+
+  <Footer slot="footer" />
+</Layout>

--- a/src/pages/pt-br/guides/[slug].astro
+++ b/src/pages/pt-br/guides/[slug].astro
@@ -3,35 +3,118 @@ import { getCollection } from 'astro:content';
 import Layout from '../../../components/layout/Layout.astro';
 import Nav from '../../../components/layout/Nav.astro';
 import Footer from '../../../components/layout/Footer.astro';
-import Hero from '../../../components/sections/Hero.astro';
-import WaitlistForm from '../../../components/sections/WaitlistForm.astro';
-import StickyWaitlistBar from '../../../components/sections/StickyWaitlistBar.astro';
+import Section from '../../../components/ui/Section.astro';
+import Button from '../../../components/ui/Button.astro';
+import Caption from '../../../components/guides/Caption.astro';
+import Note from '../../../components/guides/Note.astro';
+import TableOfContents from '../../../components/guides/TableOfContents.astro';
+import BackToTop from '../../../components/guides/BackToTop.astro';
+import ProviderArc from '../../../components/visuals/ProviderArc.astro';
+import MigrationChecklist from '../../../components/visuals/MigrationChecklist.astro';
+import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
+import PrivateRunnerPath from '../../../components/visuals/PrivateRunnerPath.astro';
+import { getT, localizedPath } from '../../../i18n/utils';
+import { readingTimeMinutes } from '../../../lib/reading-time';
 
 export async function getStaticPaths() {
   const entries = await getCollection('guides', (e) => e.data.locale === 'pt-br');
-  return entries.map((entry) => ({
-    params: { slug: entry.slug.replace(/^pt-br\//, '') },
-    props: { entry },
-  }));
+  const bySlug = new Map(entries.map((e) => [e.slug.replace(/^pt-br\//, ''), e]));
+  return entries.map((entry) => {
+    const slug = entry.slug.replace(/^pt-br\//, '');
+    const related = (entry.data.relatedSlugs ?? [])
+      .map((s) => bySlug.get(s))
+      .filter((e): e is NonNullable<typeof e> => Boolean(e))
+      .map((e) => ({
+        slug: e.slug.replace(/^pt-br\//, ''),
+        title: e.data.title,
+        description: e.data.description,
+        eyebrow: e.data.eyebrow,
+        readingTime: readingTimeMinutes(e.body ?? ''),
+      }));
+    return { params: { slug }, props: { entry, related } };
+  });
 }
 
-const { entry } = Astro.props;
-const { Content } = await entry.render();
+const { entry, related } = Astro.props;
+const { Content, headings } = await entry.render();
 const ogImage = entry.data.ogImage ?? '/og/default-pt-br.png';
+const t = getT('pt-br');
+const minutes = readingTimeMinutes(entry.body ?? '');
+const updatedLabel = new Intl.DateTimeFormat('pt-BR', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(entry.data.updatedAt);
+const updatedIso = entry.data.updatedAt.toISOString().slice(0, 10);
+const segmentHref = entry.data.waitlistSegment === 'business_migration'
+  ? '/use-cases/business-cloud-migration'
+  : '/use-cases/cloud-to-cloud-transfer';
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
   <Nav slot="nav" />
-  <Hero
-    eyebrow={entry.data.eyebrow}
-    headline={entry.data.headline}
-    subheading={entry.data.subheading}
-    primaryCta={entry.data.primaryCta}
-  />
-  <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content />
+
+  <article class="bg-reading-paper">
+    <div class="max-w-[1200px] mx-auto px-6 py-section-lg lg:grid lg:grid-cols-[220px_minmax(0,720px)_220px] lg:gap-10">
+      <aside class="hidden lg:block">
+        <div class="sticky top-24">
+          <TableOfContents headings={headings} />
+        </div>
+      </aside>
+
+      <div class="min-w-0">
+        <header class="mb-12">
+          <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{entry.data.eyebrow}</span>
+          <h1 class="text-h1 font-medium text-dark-charcoal mt-3 leading-tight">{entry.data.headline}</h1>
+          <p class="text-body text-slate-gray mt-5 leading-relaxed">{entry.data.subheading}</p>
+          <p class="text-caption text-slate-gray mt-6 flex flex-wrap gap-x-3 gap-y-1 items-center">
+            <span>{t('guides.meta.readingTime', { minutes })}</span>
+            <span aria-hidden="true">·</span>
+            <span>
+              {t('guides.meta.updated')}
+              {' '}
+              <time datetime={updatedIso}>{updatedLabel}</time>
+            </span>
+          </p>
+        </header>
+
+        <div class="prose-syncologic prose-syncologic--reading">
+          <Content components={{ ProviderArc, MigrationChecklist, ScheduleClock, PrivateRunnerPath, Caption, Note }} />
+        </div>
+      </div>
+
+      <div class="hidden lg:block" aria-hidden="true"></div>
+    </div>
   </article>
-  <WaitlistForm segmentHint={entry.data.waitlistSegment ?? null} />
+
+  <Section surface="soft" padding="md">
+    <div class="max-w-[720px] mx-auto text-center">
+      <h2 class="text-h2 font-light text-dark-charcoal">{t('guides.cta.title')}</h2>
+      <p class="text-body text-slate-gray mt-4 leading-relaxed">{t('guides.cta.body')}</p>
+      <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <Button href={localizedPath('pt-br', segmentHref)} variant="primary" size="lg">{t('guides.cta.primary')}</Button>
+        <Button href={localizedPath('pt-br', '/')} variant="secondary" size="lg">{t('guides.cta.secondary')}</Button>
+      </div>
+    </div>
+  </Section>
+
+  {related.length > 0 && (
+    <section class="bg-reading-paper py-section">
+      <div class="max-w-[960px] mx-auto px-6">
+        <h2 class="text-h1 font-medium text-dark-charcoal mb-8">{t('guides.meta.readNext')}</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {related.map((r) => (
+            <a
+              href={localizedPath('pt-br', `/guides/${r.slug}`)}
+              class="block bg-white rounded-card p-6 hover:shadow-card transition-shadow"
+            >
+              <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{r.eyebrow}</span>
+              <h3 class="text-h3 font-bold text-dark-charcoal mt-2">{r.title}</h3>
+              <p class="text-body text-slate-gray mt-3 line-clamp-3">{r.description}</p>
+              <p class="text-caption text-slate-gray mt-4">{t('guides.meta.readingTime', { minutes: r.readingTime })}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <BackToTop />
   <Footer slot="footer" />
-  <StickyWaitlistBar />
 </Layout>

--- a/src/pages/pt-br/guides/index.astro
+++ b/src/pages/pt-br/guides/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../../components/layout/Layout.astro';
+import Nav from '../../../components/layout/Nav.astro';
+import Footer from '../../../components/layout/Footer.astro';
+import { getT, localizedPath } from '../../../i18n/utils';
+import { readingTimeMinutes } from '../../../lib/reading-time';
+
+const t = getT('pt-br');
+const entries = await getCollection('guides', (e) => e.data.locale === 'pt-br');
+const guides = entries
+  .map((e) => ({
+    slug: e.slug.replace(/^pt-br\//, ''),
+    title: e.data.title,
+    description: e.data.description,
+    eyebrow: e.data.eyebrow,
+    readingTime: readingTimeMinutes(e.body ?? ''),
+    updatedAt: e.data.updatedAt,
+    updatedIso: e.data.updatedAt.toISOString().slice(0, 10),
+    updatedLabel: new Intl.DateTimeFormat('pt-BR', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).format(e.data.updatedAt),
+  }))
+  .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+const indexTitle = t('guides.index.title');
+const indexDescription = t('guides.index.description');
+---
+
+<Layout title={indexTitle} description={indexDescription}>
+  <Nav slot="nav" />
+
+  <article class="bg-reading-paper">
+    <div class="max-w-[960px] mx-auto px-6 py-section-lg">
+      <header class="max-w-[720px] mb-12">
+        <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{t('guides.index.eyebrow')}</span>
+        <h1 class="text-h1 font-medium text-dark-charcoal mt-3 leading-tight">{t('guides.index.headline')}</h1>
+        <p class="text-body text-slate-gray mt-5 leading-relaxed">{t('guides.index.subheading')}</p>
+      </header>
+
+      <ul class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {guides.map((g) => (
+          <li>
+            <a
+              href={localizedPath('pt-br', `/guides/${g.slug}`)}
+              class="block bg-white rounded-card p-6 h-full hover:shadow-card transition-shadow"
+            >
+              <span class="text-caption font-medium uppercase tracking-wide text-slate-gray">{g.eyebrow}</span>
+              <h2 class="text-h3 font-bold text-dark-charcoal mt-2">{g.title}</h2>
+              <p class="text-body text-slate-gray mt-3 line-clamp-3">{g.description}</p>
+              <p class="text-caption text-slate-gray mt-4 flex flex-wrap gap-x-3 gap-y-1">
+                <span>{t('guides.meta.readingTime', { minutes: g.readingTime })}</span>
+                <span aria-hidden="true">·</span>
+                <span>
+                  {t('guides.meta.updated')}
+                  {' '}
+                  <time datetime={g.updatedIso}>{g.updatedLabel}</time>
+                </span>
+              </p>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </article>
+
+  <Footer slot="footer" />
+</Layout>

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -10,12 +10,20 @@ import ProviderArc from '../../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../../components/visuals/MigrationChecklist.astro';
 import PrivateRunnerPath from '../../../components/visuals/PrivateRunnerPath.astro';
 import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
+import GuideCrossLinks from '../../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
   'cloud-to-cloud-transfer': ProviderArc,
   'business-cloud-migration': MigrationChecklist,
   'private-runner': PrivateRunnerPath,
   'scheduled-cloud-backup': ScheduleClock,
+};
+
+const crossLinkMap: Record<string, string[]> = {
+  'cloud-to-cloud-transfer': ['transfer-google-drive-to-onedrive', 'move-files-between-clouds-without-downloading'],
+  'business-cloud-migration': ['transfer-google-drive-to-onedrive'],
+  'scheduled-cloud-backup': ['move-files-between-clouds-without-downloading'],
+  'private-runner': ['move-files-between-clouds-without-downloading'],
 };
 
 export async function getStaticPaths() {
@@ -31,6 +39,7 @@ const slug = entry.slug.replace(/^pt-br\//, '');
 const { Content } = await entry.render();
 const ogImage = entry.data.ogImage ?? '/og/default-pt-br.png';
 const Visual = visualMap[slug];
+const crossLinks = crossLinkMap[slug] ?? [];
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
@@ -51,6 +60,7 @@ const Visual = visualMap[slug];
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
     <Content />
   </article>
+  {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />
   <Footer slot="footer" />
   <StickyWaitlistBar />

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -10,12 +10,20 @@ import ProviderArc from '../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../components/visuals/MigrationChecklist.astro';
 import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
 import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
+import GuideCrossLinks from '../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
   'cloud-to-cloud-transfer': ProviderArc,
   'business-cloud-migration': MigrationChecklist,
   'private-runner': PrivateRunnerPath,
   'scheduled-cloud-backup': ScheduleClock,
+};
+
+const crossLinkMap: Record<string, string[]> = {
+  'cloud-to-cloud-transfer': ['transfer-google-drive-to-onedrive', 'move-files-between-clouds-without-downloading'],
+  'business-cloud-migration': ['transfer-google-drive-to-onedrive'],
+  'scheduled-cloud-backup': ['move-files-between-clouds-without-downloading'],
+  'private-runner': ['move-files-between-clouds-without-downloading'],
 };
 
 export async function getStaticPaths() {
@@ -31,6 +39,7 @@ const slug = entry.slug.replace(/^en\//, '');
 const { Content } = await entry.render();
 const ogImage = entry.data.ogImage ?? '/og/default-en.png';
 const Visual = visualMap[slug];
+const crossLinks = crossLinkMap[slug] ?? [];
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
@@ -51,6 +60,7 @@ const Visual = visualMap[slug];
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
     <Content />
   </article>
+  {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />
   <Footer slot="footer" />
   <StickyWaitlistBar />

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -14,6 +14,7 @@ export default {
         'slate-gray': '#5D6C7B',
         'soft-gray': '#F1F4F7',
         'warm-gray': '#F7F8FA',
+        'reading-paper': '#F6F5F1',
         'baby-blue': '#E8F3FF',
         'near-black': '#1C1E21',
         'divider': '#DEE3E9',


### PR DESCRIPTION
## Summary
- Replace use-case-shaped guide template with a centered max-w-720 blog-post layout on a near-neutral paper surface (`reading-paper` `#F6F5F1`, sanctioned token swap — `tailwind.config.mjs`, `DESIGN.md`, and `.claude/rules/design-system.md` updated together).
- Add `/guides` index page (en + pt-br) sorted by `updatedAt` desc.
- Sticky TOC sidebar (lg+) with IntersectionObserver scroll-spy and active-link bar indicator. Hidden below lg.
- Back-to-top FAB (bottom-right, fades in past 480px scroll, respects `prefers-reduced-motion`).
- Navbar position: `absolute` on guide routes only (scrolls naturally with the page), `fixed` everywhere else. Waitlist nav button uses in-page `#waitlist` anchor on form-hosting pages, falls back to `/#waitlist` on guides.
- New MDX components surface on the guide template: `ProviderArc`, `MigrationChecklist`, `ScheduleClock`, `PrivateRunnerPath`, `Caption`, `Note`.
- TDD: `src/lib/reading-time.ts` + 10 unit tests (word-count / 200, ceil, min 1; strips frontmatter, fenced code, HTML/JSX).
- Schema additions: `updatedAt` now required (YYYY-MM-DD), `relatedSlugs` defaults to `[]`. All four existing guide MDX files backfilled from each guide's first-commit date.
- Footer Resources column now links to `/guides`. Cross-links from each use-case landing to a relevant guide.
- New i18n keys (en + pt-br placeholder per content rules): `guides.index.*`, `guides.meta.{readingTime,updated,readNext,tableOfContents,backToTop}`, `guides.callout.note`, `guides.cta.*`, `footer.resourcesColumn.*`, `useCases.furtherReading`. The `{minutes}` token is preserved across locales.

Reading-surface decision: swapped `bg-warm-gray` for the new `reading-paper` token after browser review — original `#FAFAF7` was indistinguishable from white, ended up at `#F6F5F1` (near-neutral off-white).

## Test plan
- [x] `npm run lint` clean (0 errors, 0 warnings — pre-existing hint in `RevealOnScroll.astro` is untouched)
- [x] `npm test` all passing (51 tests including 10 new reading-time tests)
- [x] `npm run build` clean — generates `/guides`, `/pt-br/guides`, both guide slugs × 2 locales
- [x] Browser pass at desktop / tablet / mobile on a guide article — TOC sticky behavior, scroll-spy, back-to-top, waitlist link, navbar absolute scroll-away
- [x] Browser pass on a non-guide page — navbar still `fixed`, in-page `#waitlist` anchor still works
- [x] hreflang correct on redesigned guide template + new index

Closes #111