### PR TITLE
Homepage: dual-audience rewrite with visual-first sections

### DIFF
--- a/.agents/rules/content/voice-and-rules.md
+++ b/.agents/rules/content/voice-and-rules.md
@@ -32,6 +32,63 @@ Don't mix them in the same paragraph. Pick the register, stick with it.
 
 ---
 
+## Brand terms come after plain-language descriptions
+
+Brand terms — "Cloud Runner", "Browser Runner", "Private Runner",
+"control plane", "data plane", "self-hosted runner", "source-visible" —
+only appear *after* a plain-language description, and as a parenthetical
+alias rather than a standalone term.
+
+Wrong: "Cloud Runner — Hosted convenience"
+Right: "On our servers (Cloud Runner) — we handle the work…"
+
+A non-technical reader has no concept of "runner". Naming the thing
+before describing it forces them to either skip the section or look up
+the term. Putting the description first lets them anchor in familiar
+language; the brand term then attaches to something they already
+understood.
+
+This applies to every public surface (homepage, use-case pages,
+`/plans`). The only exceptions are pages explicitly addressed to a
+technical audience — `/developers` and `/self-hosted` — where the
+visitor is assumed to already know the vocabulary, so the brand term can
+lead.
+
+---
+
+## Pair every section with a visual
+
+Every page section must pair with a visual that *demonstrates the
+outcome*, not just decorates the slide. The text supports what the
+visual shows. Pure-text sections need an explicit justification (FAQ
+rows, footer, legal copy, dense tables of trade-offs).
+
+Reuse the existing visual primitives before commissioning new ones:
+
+| Component | Demonstrates |
+|---|---|
+| `TransferPlanner` | A transfer running, count progressing, completion |
+| `ProviderArc` | Files moving directly from one cloud provider to another |
+| `MigrationChecklist` | Workspace migration dashboard with files, errors, progress |
+| `PrivateRunnerPath` | A file packet passing through the user's network without touching Syncologic |
+| `ScheduleClock` | A calendar where scheduled days run a backup automatically |
+| `PricingCurves` | Cloud Runner cost rising with usage versus Private Runner cost staying flat |
+| `ControlDataPlanes` | Metadata layer (control plane) above; data layer (runner with source→destination arrow) below |
+| `DeveloperTerminal` | API client showing POST /v1/jobs, the 201 response, and a webhook event |
+| `RunnerCardIllustrations` | Per-runner micro-icons for the homepage runner cards |
+| `TrustMicroVisuals` | Per-pillar trust badges (preview, scoped permissions, progress, reports, transparency) |
+
+Components live in `src/components/visuals/` (or
+`src/components/homepage/` for visuals tied to the homepage hero). When
+a section needs a new visual, name it and describe what it should
+*demonstrate* before drawing it. New visuals ship with translatable
+`alt` strings under `visuals.<name>.alt` in both `src/i18n/en.json` and
+`src/i18n/pt-br.json`. Decorative micro-icons placed next to descriptive
+text may be `aria-hidden` instead — the title and body carry the
+meaning.
+
+---
+
 ## Forbidden phrases
 
 - "Coming soon" without a concrete signal of substance.

--- a/src/components/sections/PathChooser.astro
+++ b/src/components/sections/PathChooser.astro
@@ -1,0 +1,50 @@
+---
+import Card from '../ui/Card.astro';
+import { getLocaleFromUrl, getT, localizedPath } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+---
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <a href="#how-it-works" class="block group rounded-feature">
+    <Card
+      radius="feature"
+      class="p-8 lg:p-10 transition-all group-hover:-translate-y-0.5 group-hover:shadow-card h-full"
+    >
+      <div class="flex items-start justify-between gap-4 mb-3">
+        <h3 class="text-h3 font-bold text-dark-charcoal">
+          {t('homepage.pathChooser.user.title')}
+        </h3>
+        <span
+          aria-hidden="true"
+          class="text-brand-blue text-h3 transition-transform group-hover:translate-x-1"
+          >→</span
+        >
+      </div>
+      <p class="text-body text-slate-gray leading-relaxed">
+        {t('homepage.pathChooser.user.desc')}
+      </p>
+    </Card>
+  </a>
+  <a href={localizedPath(locale, '/developers')} class="block group rounded-feature">
+    <Card
+      radius="feature"
+      class="p-8 lg:p-10 transition-all group-hover:-translate-y-0.5 group-hover:shadow-card h-full"
+    >
+      <div class="flex items-start justify-between gap-4 mb-3">
+        <h3 class="text-h3 font-bold text-dark-charcoal">
+          {t('homepage.pathChooser.dev.title')}
+        </h3>
+        <span
+          aria-hidden="true"
+          class="text-brand-blue text-h3 transition-transform group-hover:translate-x-1"
+          >→</span
+        >
+      </div>
+      <p class="text-body text-slate-gray leading-relaxed">
+        {t('homepage.pathChooser.dev.desc')}
+      </p>
+    </Card>
+  </a>
+</div>

--- a/src/components/sections/ProviderRow.astro
+++ b/src/components/sections/ProviderRow.astro
@@ -16,13 +16,11 @@ const providers = [
 ];
 ---
 
-<div class="overflow-x-auto">
-  <ul class="flex items-center gap-10 sm:gap-14 min-w-max px-4 py-6 justify-center">
-    {providers.map((p) => (
-      <li class="flex flex-col items-center gap-3 text-caption text-slate-gray whitespace-nowrap">
-        <ProviderLogo provider={p.id} size={56} />
-        <span>{t(`providers.${p.key}`)}</span>
-      </li>
-    ))}
-  </ul>
-</div>
+<ul class="flex flex-wrap items-start justify-center gap-x-10 sm:gap-x-14 gap-y-6 px-4 py-6">
+  {providers.map((p) => (
+    <li class="flex flex-col items-center gap-3 text-caption text-slate-gray whitespace-nowrap">
+      <ProviderLogo provider={p.id} size={56} />
+      <span>{t(`providers.${p.key}`)}</span>
+    </li>
+  ))}
+</ul>

--- a/src/components/sections/RunnerCards.astro
+++ b/src/components/sections/RunnerCards.astro
@@ -1,5 +1,6 @@
 ---
 import Card from '../ui/Card.astro';
+import RunnerCardIllustrations from '../visuals/RunnerCardIllustrations.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 
 const locale = getLocaleFromUrl(Astro.url);
@@ -10,9 +11,17 @@ const runners = ['cloud', 'browser', 'private'] as const;
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
   {runners.map((r) => (
-    <Card class="p-8">
-      <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{t(`runners.${r}.name`)}</h3>
-      <p class="text-caption text-slate-gray">{t(`runners.${r}.tagline`)}</p>
+    <Card class="p-8 h-full flex flex-col">
+      <RunnerCardIllustrations variant={r} />
+      <h3 class="text-h3 font-bold text-dark-charcoal mb-1">
+        {t(`runners.${r}.plainTitle`)}
+      </h3>
+      <p class="text-caption text-slate-gray mb-3">
+        ({t(`runners.${r}.name`)})
+      </p>
+      <p class="text-body text-slate-gray leading-relaxed">
+        {t(`runners.${r}.description`)}
+      </p>
     </Card>
   ))}
 </div>

--- a/src/components/sections/TrustStory.astro
+++ b/src/components/sections/TrustStory.astro
@@ -1,4 +1,5 @@
 ---
+import TrustMicroVisuals from '../visuals/TrustMicroVisuals.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 
 const locale = getLocaleFromUrl(Astro.url);
@@ -7,9 +8,10 @@ const t = getT(locale);
 const points = ['preview', 'scoped', 'progress', 'reports', 'transparency'] as const;
 ---
 
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 lg:gap-10">
   {points.map((p) => (
     <div>
+      <TrustMicroVisuals variant={p} />
       <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{t(`trust.${p}.title`)}</h3>
       <p class="text-caption text-slate-gray leading-relaxed">{t(`trust.${p}.desc`)}</p>
     </div>

--- a/src/components/sections/UseCaseRouter.astro
+++ b/src/components/sections/UseCaseRouter.astro
@@ -15,8 +15,8 @@ const useCases = [
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
   {useCases.map((u) => (
-    <a href={localizedPath(locale, `/use-cases/${u.slug}`)} class="block group">
-      <Card class="p-6 transition-transform group-hover:-translate-y-0.5 group-hover:shadow-card">
+    <a href={localizedPath(locale, `/use-cases/${u.slug}`)} class="block group h-full">
+      <Card class="p-6 h-full transition-transform group-hover:-translate-y-0.5 group-hover:shadow-card">
         <h3 class="text-h3 font-bold text-dark-charcoal mb-2">{t(`useCaseRouter.${u.key}.title`)}</h3>
         <p class="text-caption text-slate-gray">{t(`useCaseRouter.${u.key}.desc`)}</p>
       </Card>

--- a/src/components/visuals/RunnerCardIllustrations.astro
+++ b/src/components/visuals/RunnerCardIllustrations.astro
@@ -1,0 +1,131 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+type Variant = 'cloud' | 'browser' | 'private';
+interface Props {
+  variant: Variant;
+}
+
+const { variant } = Astro.props as Props;
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const altLabel = t(`visuals.runnerIllustrations.${variant}.alt`);
+---
+
+<div class="runner-illustration mb-6" role="presentation">
+  {variant === 'cloud' && (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label={altLabel}
+      class="w-24 h-24 block"
+    >
+      <path
+        d="M 32 56 a 14 14 0 0 1 14 -14 a 18 18 0 0 1 34 6 a 12 12 0 0 1 0 24 H 38 a 12 12 0 0 1 -6 -16 z"
+        class="fill-warm-gray stroke-divider"
+        stroke-width="1.5"
+      />
+      <line
+        x1="60" y1="74" x2="60" y2="80"
+        class="stroke-brand-blue"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+      <rect
+        x="32" y="80" width="56" height="14" rx="3"
+        class="fill-white stroke-divider"
+        stroke-width="1.5"
+      />
+      <circle cx="38" cy="87" r="1.5" class="fill-brand-blue" />
+      <line x1="44" y1="87" x2="80" y2="87" class="stroke-divider" stroke-width="1" />
+      <rect
+        x="32" y="98" width="56" height="14" rx="3"
+        class="fill-white stroke-divider"
+        stroke-width="1.5"
+      />
+      <circle cx="38" cy="105" r="1.5" class="fill-divider" />
+      <line x1="44" y1="105" x2="80" y2="105" class="stroke-divider" stroke-width="1" />
+    </svg>
+  )}
+
+  {variant === 'browser' && (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label={altLabel}
+      class="w-24 h-24 block"
+    >
+      <rect
+        x="14" y="22" width="92" height="76" rx="6"
+        class="fill-white stroke-divider"
+        stroke-width="1.5"
+      />
+      <line
+        x1="14" y1="36" x2="106" y2="36"
+        class="stroke-divider"
+        stroke-width="1.5"
+      />
+      <circle cx="22" cy="29" r="2" class="fill-divider" />
+      <circle cx="30" cy="29" r="2" class="fill-divider" />
+      <circle cx="38" cy="29" r="2" class="fill-divider" />
+      <rect
+        x="26" y="56" width="22" height="22" rx="4"
+        class="fill-warm-gray stroke-divider"
+        stroke-width="1"
+      />
+      <rect
+        x="72" y="56" width="22" height="22" rx="4"
+        class="fill-warm-gray stroke-divider"
+        stroke-width="1"
+      />
+      <line
+        x1="52" y1="67" x2="68" y2="67"
+        class="stroke-brand-blue"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+      <polyline
+        points="64,63 68,67 64,71"
+        class="stroke-brand-blue"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        fill="none"
+      />
+    </svg>
+  )}
+
+  {variant === 'private' && (
+    <svg
+      viewBox="0 0 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label={altLabel}
+      class="w-24 h-24 block"
+    >
+      <path
+        d="M 18 56 L 60 22 L 102 56"
+        class="stroke-divider"
+        stroke-width="1.5"
+        fill="none"
+        stroke-linejoin="round"
+        stroke-dasharray="4 4"
+      />
+      <rect
+        x="30" y="50" width="60" height="42" rx="4"
+        class="fill-white stroke-divider"
+        stroke-width="1.5"
+      />
+      <rect x="50" y="92" width="20" height="4" class="fill-divider" />
+      <rect x="42" y="96" width="36" height="3" rx="1.5" class="fill-divider" />
+      <path
+        d="M 46 64 H 54 L 56 67 H 74 V 80 H 46 Z"
+        class="fill-warm-gray stroke-brand-blue"
+        stroke-width="1.5"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )}
+</div>

--- a/src/components/visuals/TrustMicroVisuals.astro
+++ b/src/components/visuals/TrustMicroVisuals.astro
@@ -1,0 +1,27 @@
+---
+import { Eye, KeyRound, Activity, ClipboardList, Compass } from '@lucide/astro';
+
+type Variant = 'preview' | 'scoped' | 'progress' | 'reports' | 'transparency';
+interface Props {
+  variant: Variant;
+}
+
+const { variant } = Astro.props as Props;
+
+const icons = {
+  preview: Eye,
+  scoped: KeyRound,
+  progress: Activity,
+  reports: ClipboardList,
+  transparency: Compass,
+} as const;
+
+const Icon = icons[variant];
+---
+
+<div
+  class="inline-flex items-center justify-center w-12 h-12 rounded-pill bg-baby-blue text-dark-charcoal mb-4"
+  aria-hidden="true"
+>
+  <Icon size={24} stroke-width={1.75} />
+</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -103,7 +103,7 @@
     "private": {
       "name": "Private Runner",
       "plainTitle": "On your own machine",
-      "description": "Install a small program. Files never touch our servers. For businesses, homelabs, and sensitive data."
+      "description": "Install a small program. Files never touch our servers. Perfect for businesses, homelabs, and sensitive data."
     }
   },
   "useCaseRouter": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -19,8 +19,8 @@
       }
     },
     "providersLabel": "Connects to",
-    "runnersTitle": "Three ways to run a transfer",
-    "runnersSubtitle": "Pick the runner that matches your trust and convenience needs.",
+    "runnersTitle": "Where does the transfer happen?",
+    "runnersSubtitle": "Three options with very different trade-offs in cost, convenience, and privacy.",
     "useCasesTitle": "Find your use case",
     "useCasesSubtitle": "We're building for several different audiences — start with the one that fits.",
     "trustTitle": "Built around your trust",
@@ -90,9 +90,21 @@
     "other": "Other"
   },
   "runners": {
-    "cloud": { "name": "Cloud Runner", "tagline": "Hosted convenience" },
-    "browser": { "name": "Browser Runner", "tagline": "Run it in a tab" },
-    "private": { "name": "Private Runner", "tagline": "Your machine, your bandwidth" }
+    "cloud": {
+      "name": "Cloud Runner",
+      "plainTitle": "On our servers",
+      "description": "We handle the work. Close your browser, go to sleep — the transfer keeps running. Pay for what you use."
+    },
+    "browser": {
+      "name": "Browser Runner",
+      "plainTitle": "In your browser tab",
+      "description": "The tab has to stay open. Free. Best for a one-time transfer."
+    },
+    "private": {
+      "name": "Private Runner",
+      "plainTitle": "On your own machine",
+      "description": "Install a small program. Files never touch our servers. For businesses, homelabs, and sensitive data."
+    }
   },
   "useCaseRouter": {
     "cloudToCloud": {
@@ -202,6 +214,17 @@
     },
     "developerTerminal": {
       "alt": "An API client showing a POST /v1/jobs request being sent to the Syncologic API, the 201 Created response with a run id and plan, and a webhook event for the completed run."
+    },
+    "runnerIllustrations": {
+      "cloud": {
+        "alt": "Cloud icon above two stacked server units, representing transfers running on Syncologic's hosted infrastructure."
+      },
+      "browser": {
+        "alt": "Browser window with two file boxes connected by an arrow, representing a transfer that runs inside the user's browser tab."
+      },
+      "private": {
+        "alt": "Desktop computer holding a folder, framed by a dashed roof outline that stands for the user's local network — the transfer runs on their own machine."
+      }
     }
   },
   "guides": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,7 +7,17 @@
   "homepage": {
     "heroEyebrow": "Cloud-to-cloud transfer",
     "heroBody": "Connect a source and destination, preview what changes, then run the transfer in the cloud or on your own machine.",
-    "heroSecondaryCta": "See how it works",
+    "pathChooser": {
+      "eyebrow": "Where to start",
+      "user": {
+        "title": "I want to move my files",
+        "desc": "See how a transfer works end to end, then pick the path that fits your case."
+      },
+      "dev": {
+        "title": "I'm building with this",
+        "desc": "Use the API, CLI, webhooks, or self-host the runner. We handle OAuth — your users connect to Syncologic, not to your app."
+      }
+    },
     "providersLabel": "Connects to",
     "runnersTitle": "Three ways to run a transfer",
     "runnersSubtitle": "Pick the runner that matches your trust and convenience needs.",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -93,17 +93,17 @@
     "cloud": {
       "name": "Cloud Runner",
       "plainTitle": "Pelos nossos servidores",
-      "description": "A gente cuida do trabalho. Fecha o navegador, vai dormir — a transferência continua rodando. Você paga pelo uso."
+      "description": "Hospedamos a transferência. Você fecha o navegador e ela continua rodando. Cobramos pelo uso."
     },
     "browser": {
       "name": "Browser Runner",
       "plainTitle": "Na aba do seu navegador",
-      "description": "A aba precisa ficar aberta. De graça. Boa pra uma transferência única."
+      "description": "A aba precisa ficar aberta enquanto roda. Sem custo. Boa pra uma transferência única."
     },
     "private": {
       "name": "Private Runner",
       "plainTitle": "Na sua própria máquina",
-      "description": "Você instala um programinha. Os arquivos nunca passam pelos nossos servidores. Para empresas, homelabs e dados sensíveis."
+      "description": "Você instala um programinha. Os arquivos nunca passam pelos nossos servidores. Perfeito para empresas, homelabs e dados sensíveis."
     }
   },
   "useCaseRouter": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -7,7 +7,17 @@
   "homepage": {
     "heroEyebrow": "Transferência entre nuvens",
     "heroBody": "Conecte origem e destino, veja a prévia das mudanças e execute a transferência na nuvem ou na sua máquina.",
-    "heroSecondaryCta": "Veja como funciona",
+    "pathChooser": {
+      "eyebrow": "Por onde começar",
+      "user": {
+        "title": "Quero mover meus arquivos",
+        "desc": "Veja como uma transferência funciona de ponta a ponta e escolha o caminho que combina com o seu caso."
+      },
+      "dev": {
+        "title": "Estou construindo algo com isso",
+        "desc": "Use a API, a CLI, webhooks ou hospede o runner por conta própria. A gente cuida do OAuth — seus usuários conectam à Syncologic, não ao seu app."
+      }
+    },
     "providersLabel": "Funciona com",
     "runnersTitle": "Três formas de executar uma transferência",
     "runnersSubtitle": "Escolha o runner que melhor equilibra confiança e praticidade para você.",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -19,8 +19,8 @@
       }
     },
     "providersLabel": "Funciona com",
-    "runnersTitle": "Três formas de executar uma transferência",
-    "runnersSubtitle": "Escolha o runner que melhor equilibra confiança e praticidade para você.",
+    "runnersTitle": "Onde a transferência acontece?",
+    "runnersSubtitle": "Três opções com perfis bem diferentes de praticidade, custo e privacidade.",
     "useCasesTitle": "Encontre seu caso de uso",
     "useCasesSubtitle": "Estamos construindo para vários tipos de públicos — comece pelo que faz mais sentido para você.",
     "trustTitle": "Sua confiança em primeiro lugar",
@@ -90,9 +90,21 @@
     "other": "Outro"
   },
   "runners": {
-    "cloud": { "name": "Cloud Runner", "tagline": "Praticidade na nuvem" },
-    "browser": { "name": "Browser Runner", "tagline": "Rode em uma aba" },
-    "private": { "name": "Private Runner", "tagline": "Sua máquina, sua banda" }
+    "cloud": {
+      "name": "Cloud Runner",
+      "plainTitle": "Pelos nossos servidores",
+      "description": "A gente cuida do trabalho. Fecha o navegador, vai dormir — a transferência continua rodando. Você paga pelo uso."
+    },
+    "browser": {
+      "name": "Browser Runner",
+      "plainTitle": "Na aba do seu navegador",
+      "description": "A aba precisa ficar aberta. De graça. Boa pra uma transferência única."
+    },
+    "private": {
+      "name": "Private Runner",
+      "plainTitle": "Na sua própria máquina",
+      "description": "Você instala um programinha. Os arquivos nunca passam pelos nossos servidores. Para empresas, homelabs e dados sensíveis."
+    }
   },
   "useCaseRouter": {
     "cloudToCloud": {
@@ -202,6 +214,17 @@
     },
     "developerTerminal": {
       "alt": "Um cliente de API mostrando uma requisição POST /v1/jobs sendo enviada para a API da Syncologic, a resposta 201 Created com um id de run e um plano, e um evento de webhook para o run concluído."
+    },
+    "runnerIllustrations": {
+      "cloud": {
+        "alt": "Ícone de nuvem acima de duas unidades de servidor empilhadas, representando transferências rodando na infraestrutura hospedada da Syncologic."
+      },
+      "browser": {
+        "alt": "Janela de navegador com duas caixas de arquivo conectadas por uma seta, representando uma transferência que roda na aba do usuário."
+      },
+      "private": {
+        "alt": "Computador desktop guardando uma pasta, com um contorno tracejado em forma de telhado representando a rede local do usuário — a transferência roda na máquina dele."
+      }
     }
   },
   "guides": {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import ProviderRow from '../components/sections/ProviderRow.astro';
 import RunnerCards from '../components/sections/RunnerCards.astro';
 import UseCaseRouter from '../components/sections/UseCaseRouter.astro';
 import TrustStory from '../components/sections/TrustStory.astro';
+import PathChooser from '../components/sections/PathChooser.astro';
 import WaitlistForm from '../components/sections/WaitlistForm.astro';
 import { getLocaleFromUrl, getT } from '../i18n/utils';
 
@@ -59,15 +60,21 @@ const siteSchema = {
           <Button href="#waitlist" variant="primary" size="lg">
             {t('nav.joinWaitlist')}
           </Button>
-          <Button href="#how-it-works" variant="secondary" size="lg">
-            {t('homepage.heroSecondaryCta')}
-          </Button>
         </div>
       </div>
       <div>
         <TransferPlanner />
       </div>
     </div>
+  </Section>
+
+  <Section surface="white" padding="md">
+    <p
+      class="text-caption text-center text-slate-gray uppercase tracking-wide mb-6"
+    >
+      {t('homepage.pathChooser.eyebrow')}
+    </p>
+    <PathChooser />
   </Section>
 
   <Section surface="soft" padding="md">

--- a/src/pages/pt-br/index.astro
+++ b/src/pages/pt-br/index.astro
@@ -10,6 +10,7 @@ import ProviderRow from '../../components/sections/ProviderRow.astro';
 import RunnerCards from '../../components/sections/RunnerCards.astro';
 import UseCaseRouter from '../../components/sections/UseCaseRouter.astro';
 import TrustStory from '../../components/sections/TrustStory.astro';
+import PathChooser from '../../components/sections/PathChooser.astro';
 import WaitlistForm from '../../components/sections/WaitlistForm.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 
@@ -59,15 +60,21 @@ const siteSchema = {
           <Button href="#waitlist" variant="primary" size="lg">
             {t('nav.joinWaitlist')}
           </Button>
-          <Button href="#how-it-works" variant="secondary" size="lg">
-            {t('homepage.heroSecondaryCta')}
-          </Button>
         </div>
       </div>
       <div>
         <TransferPlanner />
       </div>
     </div>
+  </Section>
+
+  <Section surface="white" padding="md">
+    <p
+      class="text-caption text-center text-slate-gray uppercase tracking-wide mb-6"
+    >
+      {t('homepage.pathChooser.eyebrow')}
+    </p>
+    <PathChooser />
   </Section>
 
   <Section surface="soft" padding="md">


### PR DESCRIPTION
## Summary
- Replaces the hero's "See how it works" secondary CTA with a dedicated path-chooser section: two large cards routing non-technical visitors to the runners + use-case sections, and developer/IT visitors to `/developers`. Plants the OAuth-intermediary value prop right at the entrance.
- Rewrites the runner cards so each one leads with a plain-language title ("On our servers", "In your browser tab", "On your own machine"), shows the brand name as a parenthetical alias, and pairs with a small SVG illustration. Section heading reframed as "Where does the transfer happen?".
- Adds icon badges to the trust block (preview, scoped permissions, progress, reports, transparency) so the section demonstrates rather than narrates.
- Codifies the rewrite conventions in `.agents/rules/content/voice-and-rules.md`: brand terms only after plain-language descriptions, every section paired with a visual or justified as text-only, plus a reference table of the visual primitives in the repo.

## Closes
Closes #144

## Test plan
- [x] `npm run lint`
- [x] `npm test` (51/51 passing)
- [x] `npm run build`
- [ ] Mobile (375px) + desktop (1280px) in EN and pt-BR — please verify on the Vercel preview (see "Visual verification" below)
- [x] Jargon check — every "runner" inside `homepage.*` / `runners.*` JSON keys is either a parenthetical alias, an internal visual label, or intentional in the dev-targeted path-chooser card.
- [x] `prefers-reduced-motion` — new components have no animation, so no regression possible.

## Visual verification (UI changes only)
**Not performed in a real browser** — opening on the Vercel preview deployment is the recommended verification path. Specifically check:
- Hero on `/` and `/pt-br/` — single primary CTA ("Join the waitlist"); no secondary button below.
- Path-chooser section directly below the hero, two cards side-by-side on desktop, stacked on mobile, arrow indicators turning on hover.
- Runner cards ("Where does the transfer happen?") with the new SVG illustration on top of each card.
- Trust block with five small icon badges on baby-blue background, one per pillar.
- Same on `/pt-br/` with translated copy.

## Notes
- No new dependencies. Uses `@lucide/astro` (already in deps) for the trust icons.
- One i18n key removed (`homepage.heroSecondaryCta`); two structural keys removed (`runners.*.tagline`); five new structural keys (`runners.*.{plainTitle,description}`); two new visual scopes (`visuals.runnerIllustrations.*`, plus the path-chooser section under `homepage.pathChooser.*`).
- Brazilian Portuguese copy was written natively, matching the rest of the file.
- First in a planned sequence of focused issues that rewrite each marketing page for dual-audience clarity.