### PR TITLE
Use-case pages: rewrite cloud-to-cloud + business-migration with audience-first copy and a paired before/after visual

### DIFF
--- a/src/components/visuals/BeforeAfterTransfer.astro
+++ b/src/components/visuals/BeforeAfterTransfer.astro
@@ -15,25 +15,25 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
     class="w-full h-auto block"
   >
     <g aria-hidden="true">
-      <rect x="20" y="40" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <rect x="20" y="40" width="100" height="80" rx="14" class="fill-soft-gray" />
       <path
         d="M 50 88 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 56 a 8 8 0 0 1 -6 -10 z"
-        class="fill-white stroke-divider"
+        class="fill-white stroke-slate-gray"
         stroke-width="1.2"
       />
     </g>
 
     <g aria-hidden="true">
-      <rect x="200" y="50" width="80" height="50" rx="6" class="fill-white stroke-divider" stroke-width="1.5" />
-      <rect x="208" y="58" width="64" height="34" rx="2" class="fill-warm-gray" />
-      <rect x="190" y="100" width="100" height="6" rx="3" class="fill-divider" />
+      <rect x="200" y="50" width="80" height="50" rx="6" class="fill-white stroke-slate-gray" stroke-width="1.5" />
+      <rect x="208" y="58" width="64" height="34" rx="2" class="fill-soft-gray" />
+      <rect x="190" y="100" width="100" height="6" rx="3" class="fill-slate-gray" />
     </g>
 
     <g aria-hidden="true">
-      <rect x="360" y="40" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <rect x="360" y="40" width="100" height="80" rx="14" class="fill-soft-gray" />
       <path
         d="M 390 88 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 396 a 8 8 0 0 1 -6 -10 z"
-        class="fill-white stroke-divider"
+        class="fill-white stroke-slate-gray"
         stroke-width="1.2"
       />
     </g>
@@ -44,7 +44,7 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
       stroke-width="1.5"
       stroke-dasharray="2 6"
       stroke-linecap="round"
-      class="stroke-divider"
+      class="stroke-slate-gray"
       aria-hidden="true"
     />
     <path
@@ -53,9 +53,22 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
       stroke-width="1.5"
       stroke-dasharray="2 6"
       stroke-linecap="round"
-      class="stroke-divider"
+      class="stroke-slate-gray"
       aria-hidden="true"
     />
+
+    <g class="manual-pills" aria-hidden="true">
+      <g class="manual-pill manual-pill-a">
+        <rect class="pill-body" x="-22" y="-10" width="44" height="20" rx="10" stroke-width="1" />
+        <line class="pill-line" x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" />
+        <line class="pill-line" x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" />
+      </g>
+      <g class="manual-pill manual-pill-b">
+        <rect class="pill-body" x="-22" y="-10" width="44" height="20" rx="10" stroke-width="1" />
+        <line class="pill-line" x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" />
+        <line class="pill-line" x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" />
+      </g>
+    </g>
 
     <line
       x1="40" y1="195" x2="440" y2="195"
@@ -66,19 +79,19 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
     />
 
     <g aria-hidden="true">
-      <rect x="20" y="240" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <rect x="20" y="240" width="100" height="80" rx="14" class="fill-soft-gray" />
       <path
         d="M 50 288 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 56 a 8 8 0 0 1 -6 -10 z"
-        class="fill-white stroke-divider"
+        class="fill-white stroke-slate-gray"
         stroke-width="1.2"
       />
     </g>
 
     <g aria-hidden="true">
-      <rect x="360" y="240" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <rect x="360" y="240" width="100" height="80" rx="14" class="fill-soft-gray" />
       <path
         d="M 390 288 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 396 a 8 8 0 0 1 -6 -10 z"
-        class="fill-white stroke-divider"
+        class="fill-white stroke-slate-gray"
         stroke-width="1.2"
       />
     </g>
@@ -117,6 +130,20 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
 <style>
   .before-after { min-width: 280px; }
 
+  .manual-pill {
+    offset-path: path('M 120 80 Q 180 75 240 75 Q 300 85 360 80');
+    offset-distance: 0%;
+    offset-rotate: 0deg;
+    opacity: 0;
+  }
+  .manual-pill .pill-body {
+    fill: white;
+    stroke: var(--color-brand-blue);
+  }
+  .manual-pill .pill-line {
+    stroke: var(--color-brand-blue);
+  }
+
   .file-pill {
     offset-path: path('M 120 280 Q 240 180 360 280');
     offset-distance: 0%;
@@ -125,12 +152,58 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
   }
 
   @media (prefers-reduced-motion: no-preference) {
+    .manual-pill-a {
+      animation: manual-pill-trip 12s ease-in-out infinite;
+    }
+    .manual-pill-b {
+      animation: manual-pill-trip 15s ease-in-out infinite 7s;
+    }
+    .manual-pill-a .pill-body { animation: manual-pill-body 12s linear infinite; }
+    .manual-pill-a .pill-line { animation: manual-pill-line 12s linear infinite; }
+    .manual-pill-b .pill-body { animation: manual-pill-body 15s linear infinite 7s; }
+    .manual-pill-b .pill-line { animation: manual-pill-line 15s linear infinite 7s; }
+
     .file-pill {
-      animation: before-after-pill 4.5s ease-in-out infinite;
+      animation: before-after-pill 2.5s ease-in-out infinite;
       animation-delay: var(--pill-delay, 0s);
     }
     .arc-flow {
-      animation: before-after-flow 1.6s linear infinite;
+      animation: before-after-flow 1.2s linear infinite;
+    }
+
+    @keyframes manual-pill-trip {
+      0%   { offset-distance: 0%;   opacity: 0; }
+      3%   { offset-distance: 4%;   opacity: 1; }
+      11%  { offset-distance: 30%;  opacity: 1; }
+      22%  { offset-distance: 50%;  opacity: 1; }
+      30%  { offset-distance: 100%; opacity: 1; }
+      33%  { offset-distance: 100%; opacity: 0; }
+      35%  { offset-distance: 0%;   opacity: 0; }
+      37%  { offset-distance: 4%;   opacity: 1; }
+      45%  { offset-distance: 30%;  opacity: 1; }
+      56%  { offset-distance: 50%;  opacity: 1; }
+      64%  { offset-distance: 100%; opacity: 1; }
+      67%  { offset-distance: 100%; opacity: 0; }
+      69%  { offset-distance: 0%;   opacity: 0; }
+      71%  { offset-distance: 4%;   opacity: 1; }
+      79%  { offset-distance: 30%;  opacity: 1; }
+      88%  { offset-distance: 50%;  opacity: 1; }
+      94%  { offset-distance: 50%;  opacity: 1; }
+      99%  { offset-distance: 50%;  opacity: 0; }
+      100% { offset-distance: 50%;  opacity: 0; }
+    }
+
+    @keyframes manual-pill-body {
+      0%, 88%    { fill: white; stroke: var(--color-brand-blue); }
+      88.01%     { fill: var(--color-error); stroke: var(--color-error); }
+      99%        { fill: var(--color-error); stroke: var(--color-error); }
+      100%       { fill: white; stroke: var(--color-brand-blue); }
+    }
+    @keyframes manual-pill-line {
+      0%, 88%    { stroke: var(--color-brand-blue); }
+      88.01%     { stroke: white; }
+      99%        { stroke: white; }
+      100%       { stroke: var(--color-brand-blue); }
     }
 
     @keyframes before-after-pill {
@@ -146,6 +219,8 @@ const altLabel = t('visuals.beforeAfterTransfer.alt');
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .manual-pill-a { offset-distance: 25%; opacity: 1; }
+    .manual-pill-b { offset-distance: 75%; opacity: 1; }
     .file-pill { opacity: 1; }
     .file-pill:nth-child(1) { offset-distance: 35%; }
     .file-pill:nth-child(2) { offset-distance: 65%; }

--- a/src/components/visuals/BeforeAfterTransfer.astro
+++ b/src/components/visuals/BeforeAfterTransfer.astro
@@ -1,0 +1,153 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const altLabel = t('visuals.beforeAfterTransfer.alt');
+---
+
+<div class="before-after w-full max-w-[480px] mx-auto" role="presentation">
+  <svg
+    viewBox="0 0 480 380"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label={altLabel}
+    class="w-full h-auto block"
+  >
+    <g aria-hidden="true">
+      <rect x="20" y="40" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <path
+        d="M 50 88 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 56 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-divider"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="200" y="50" width="80" height="50" rx="6" class="fill-white stroke-divider" stroke-width="1.5" />
+      <rect x="208" y="58" width="64" height="34" rx="2" class="fill-warm-gray" />
+      <rect x="190" y="100" width="100" height="6" rx="3" class="fill-divider" />
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="360" y="40" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <path
+        d="M 390 88 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 396 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-divider"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <path
+      d="M 120 80 Q 160 70 200 80"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="stroke-divider"
+      aria-hidden="true"
+    />
+    <path
+      d="M 280 80 Q 320 90 360 80"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="stroke-divider"
+      aria-hidden="true"
+    />
+
+    <line
+      x1="40" y1="195" x2="440" y2="195"
+      class="stroke-divider"
+      stroke-width="1"
+      stroke-dasharray="4 6"
+      aria-hidden="true"
+    />
+
+    <g aria-hidden="true">
+      <rect x="20" y="240" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <path
+        d="M 50 288 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 56 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-divider"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="360" y="240" width="100" height="80" rx="14" class="fill-warm-gray" />
+      <path
+        d="M 390 288 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 396 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-divider"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <path
+      d="M 120 280 Q 240 180 360 280"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="arc-flow stroke-divider"
+    />
+    <path
+      d="M 120 280 Q 240 180 360 280"
+      fill="none"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      class="stroke-brand-blue"
+    />
+
+    <g class="file-pills" aria-hidden="true">
+      <g class="file-pill" style="--pill-delay: 0s;">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+      </g>
+      <g class="file-pill" style="--pill-delay: 0.6s;">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+      </g>
+    </g>
+  </svg>
+</div>
+
+<style>
+  .before-after { min-width: 280px; }
+
+  .file-pill {
+    offset-path: path('M 120 280 Q 240 180 360 280');
+    offset-distance: 0%;
+    offset-rotate: 0deg;
+    opacity: 0;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .file-pill {
+      animation: before-after-pill 4.5s ease-in-out infinite;
+      animation-delay: var(--pill-delay, 0s);
+    }
+    .arc-flow {
+      animation: before-after-flow 1.6s linear infinite;
+    }
+
+    @keyframes before-after-pill {
+      0%   { offset-distance: 0%;   opacity: 0; }
+      8%   { offset-distance: 4%;   opacity: 1; }
+      72%  { offset-distance: 100%; opacity: 1; }
+      80%  { offset-distance: 100%; opacity: 0; }
+      100% { offset-distance: 100%; opacity: 0; }
+    }
+    @keyframes before-after-flow {
+      to { stroke-dashoffset: -16; }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .file-pill { opacity: 1; }
+    .file-pill:nth-child(1) { offset-distance: 35%; }
+    .file-pill:nth-child(2) { offset-distance: 65%; }
+  }
+</style>

--- a/src/content/use-cases/en/business-cloud-migration.mdx
+++ b/src/content/use-cases/en/business-cloud-migration.mdx
@@ -17,39 +17,38 @@ publishedAt: 2026-05-01
 
 ## Who this is for
 
-- Founders and ops leads switching the company from Google Workspace to Microsoft 365 or back the other way.
-- IT generalists at small businesses replacing Dropbox Business with a workspace plan.
-- Anyone who has been told "just download everything and re-upload it" and knows that won't survive contact with reality.
+- You're a founder or ops lead switching the company between Google Workspace and Microsoft 365.
+- You're the IT generalist at a small business replacing Dropbox Business with a workspace plan.
+- Someone told you "just download everything and re-upload it" and you already know that won't survive contact with reality.
 
 ## Why business migrations are different
 
-A personal move can tolerate a missed file. A business move can't. Stakeholders ask three questions: what's about to change, did it finish, and what didn't make it. The answer to all three needs to be a document, not a guess.
+A personal move can lose a file and shrug. A business move can't. Three questions show up in every meeting: what's about to change, did it finish, and what didn't make it. The answer to all three needs to be a document, not a guess.
 
-Manual workspace migrations turn into missing files, duplicated folders, and quiet permission drift. The fix isn't more spreadsheets — it's visibility built into the transfer.
+Manual workspace migrations turn into missing files, duplicated folders, and quiet permission drift. Spreadsheets don't fix that — visibility built into the transfer does.
 
 ## How it'll work
 
 1. Connect the source workspace — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
 2. Connect the destination workspace.
 3. Run a preview to see exactly what will copy, what already matches, and how much data will move.
-4. Pick a runner — Cloud Runner for convenience, Private Runner if the data has to stay in your own infrastructure.
-5. Run the transfer, watch progress, and download the completion report.
+4. Run the transfer, watch progress in the dashboard, and download the completion report.
 
 ## Preview before you commit
 
-Every job will start with a dry-run — file count, total size, folders involved, conflicts. Stakeholders can sign off on the preview instead of trusting a verbal estimate.
+Every job starts with a dry-run — file count, total size, folders involved, conflicts. Stakeholders sign off on a preview instead of trusting a verbal estimate. If something looks wrong, you adjust before a single byte moves.
 
 ## A report at the end
 
-When a run finishes, you'll get a structured report — what copied, what was skipped, what failed and why. Keep it for the audit trail. Re-run only the failed items if anything needs a second pass.
+When a run finishes, you get a structured report — what copied, what was skipped, what failed and why. Keep it for the audit trail. Re-run only the failed items if anything needs a second pass.
 
 ## Schedule the cutover
 
 Plan migrations in stages instead of one weekend marathon. Schedule a job for off-hours. Run a delta the morning of the cutover so the destination is current. Pause and resume between phases.
 
-## Private Runner for sensitive moves
+## Keep sensitive data on your own server
 
-Some data shouldn't pass through anyone else's infrastructure — legal archives, financial records, regulated content. Run those through a Private Runner on your own server, NAS, or VPS. Bytes stay on your network; the control plane only coordinates.
+Some data shouldn't pass through anyone else's infrastructure — legal archives, financial records, regulated content. Run those transfers on a server you control (we call it a Private Runner). The bytes stay on your network; we only coordinate the job from the outside.
 
 ## Common workspace pairs
 

--- a/src/content/use-cases/en/cloud-to-cloud-transfer.mdx
+++ b/src/content/use-cases/en/cloud-to-cloud-transfer.mdx
@@ -17,29 +17,25 @@ publishedAt: 2026-04-30
 
 ## Who this is for
 
-- People switching from one cloud drive to another and tired of dragging gigabytes through a browser tab.
-- Small teams consolidating files across Google Drive, OneDrive, Dropbox, and S3-compatible storage.
-- Anyone who has watched a manual download stall on a folder larger than their laptop's free disk space.
+- You're switching from one cloud drive to another and you're tired of dragging gigabytes through a browser tab.
+- You're consolidating files across Google Drive, OneDrive, Dropbox, and S3 and want one transfer instead of ten.
+- You've watched a manual download stall on a folder bigger than your laptop's free disk space.
 
 ## How it'll work
 
-1. Connect the source provider — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
-2. Connect the destination provider.
-3. Preview the diff: which files will copy, which already match, and how much will move.
-4. Pick a runner — Cloud Runner for convenience, Browser Runner for a transparent path through your tab, or Private Runner on your own server.
-5. Run the transfer and download a report when it finishes.
+1. Connect the source — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV, or Nextcloud.
+2. Connect the destination.
+3. Run a preview: which files will copy, which already match, and how much will move.
+4. Confirm and run the transfer.
+5. Download a report when it's done.
 
 ## Why this beats download-and-reupload
 
-Manual transfers pull every file through your laptop, then push the same bytes back up. Large folders fail halfway. Browser downloads time out. Drives fill up.
+A manual move takes the long way around. Every file leaves the source cloud, lands on your laptop, then travels back up to the destination cloud. Two trips, two chances to fail, and your disk has to be big enough to hold the middle of the trip.
 
-A direct cloud-to-cloud transfer moves the bytes between providers without parking them on your machine. You'll see what's about to change before it runs, and get a report when it's done.
+A direct transfer skips the middle. The bytes move between providers without ever parking on your laptop. You see what's about to change before it runs, and a report when it's done.
 
-## Three ways to run a transfer at launch
-
-- **Cloud Runner.** Source provider to Syncologic infrastructure to destination provider. Best for convenience and large jobs you don't want to babysit.
-- **Browser Runner.** Source provider to your browser tab to destination provider. The tab will need to stay open while it runs. Best when you want a transparent path with nothing hosted on your behalf.
-- **Private Runner.** Source provider to your own server, NAS, or VPS to destination provider. Best when bytes and credentials must stay in infrastructure you control.
+<BeforeAfterTransfer />
 
 ## Common provider pairs
 

--- a/src/content/use-cases/pt-br/business-cloud-migration.mdx
+++ b/src/content/use-cases/pt-br/business-cloud-migration.mdx
@@ -17,39 +17,38 @@ publishedAt: 2026-05-01
 
 ## Para quem é isso
 
-- Fundadores e líderes de operações trocando a empresa do Google Workspace para o Microsoft 365 ou no sentido contrário.
-- Generalistas de TI em pequenas empresas trocando o Dropbox Business por um plano de workspace.
-- Quem já ouviu "é só baixar tudo e subir de novo" e sabe que isso não sobrevive ao contato com a realidade.
+- Você é fundador ou líder de operações trocando a empresa entre Google Workspace e Microsoft 365.
+- Você é o generalista de TI de uma pequena empresa trocando o Dropbox Business por um plano de workspace.
+- Alguém te disse "é só baixar tudo e subir de novo" e você já sabe que isso não sobrevive ao contato com a realidade.
 
 ## Por que migrações empresariais são diferentes
 
-Uma migração pessoal aguenta um arquivo perdido. Uma empresarial, não. Stakeholders fazem três perguntas: o que vai mudar, terminou, e o que não chegou. A resposta para as três precisa ser um documento, não um chute.
+Uma migração pessoal pode perder um arquivo e dar de ombros. Uma empresarial, não. Três perguntas aparecem em toda reunião: o que vai mudar, terminou, e o que não chegou. A resposta para as três precisa ser um documento, não um chute.
 
-Migrações manuais de workspace viram arquivos perdidos, pastas duplicadas e desvios silenciosos de permissão. A solução não é mais planilhas — é visibilidade embutida na transferência.
+Migrações manuais de workspace viram arquivos perdidos, pastas duplicadas e desvios silenciosos de permissão. Planilha não resolve — o que resolve é visibilidade embutida na transferência.
 
 ## Como vai funcionar
 
 1. Conecte o workspace de origem — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV ou Nextcloud.
 2. Conecte o workspace de destino.
 3. Rode uma prévia para ver exatamente o que vai ser copiado, o que já coincide e quantos dados vão se mover.
-4. Escolha um runner — Cloud Runner para praticidade, Private Runner se os dados precisam ficar na sua própria infraestrutura.
-5. Rode a transferência, acompanhe o progresso e baixe o relatório de conclusão.
+4. Rode a transferência, acompanhe o progresso no painel e baixe o relatório de conclusão.
 
 ## Pré-visualize antes de confirmar
 
-Todo job vai começar com um dry-run — contagem de arquivos, tamanho total, pastas envolvidas, conflitos. Os stakeholders aprovam a prévia em vez de confiar em uma estimativa verbal.
+Todo job começa com um dry-run — contagem de arquivos, tamanho total, pastas envolvidas, conflitos. Os stakeholders aprovam uma prévia em vez de confiar em uma estimativa verbal. Se algo parecer errado, dá para ajustar antes de um único byte se mover.
 
 ## Um relatório no final
 
-Quando um run terminar, você recebe um relatório estruturado — o que foi copiado, o que foi ignorado, o que falhou e por quê. Guarde para a trilha de auditoria. Rode de novo só os itens que falharam se algo precisar de uma segunda passada.
+Quando um run termina, você recebe um relatório estruturado — o que foi copiado, o que foi ignorado, o que falhou e por quê. Guarde para a trilha de auditoria. Rode de novo só os itens que falharam se algo precisar de uma segunda passada.
 
 ## Agende o cutover
 
 Planeje migrações em etapas em vez de uma maratona de fim de semana. Agende um job para fora do horário comercial. Rode um delta na manhã do cutover para o destino ficar em dia. Pause e retome entre as fases.
 
-## Private Runner para movimentações sensíveis
+## Mantenha dados sensíveis no seu próprio servidor
 
-Alguns dados não devem passar pela infraestrutura de mais ninguém — arquivos jurídicos, registros financeiros, conteúdo regulado. Rode esses por um Private Runner no seu próprio servidor, NAS ou VPS. Os bytes ficam na sua rede; a camada de controle só coordena.
+Alguns dados não devem passar pela infraestrutura de mais ninguém — arquivos jurídicos, registros financeiros, conteúdo regulado. Rode essas transferências em um servidor que você controla (a gente chama de Private Runner). Os bytes ficam na sua rede; a gente só coordena o job de fora.
 
 ## Pares de workspaces comuns
 

--- a/src/content/use-cases/pt-br/cloud-to-cloud-transfer.mdx
+++ b/src/content/use-cases/pt-br/cloud-to-cloud-transfer.mdx
@@ -17,29 +17,25 @@ publishedAt: 2026-04-30
 
 ## Para quem é isso
 
-- Quem está trocando de uma nuvem para outra e cansou de arrastar gigabytes por uma aba de navegador.
-- Times pequenos consolidando arquivos entre Google Drive, OneDrive, Dropbox e armazenamento compatível com S3.
-- Qualquer pessoa que já viu um download manual travar em uma pasta maior que o espaço livre do disco do notebook.
+- Você está trocando de uma nuvem para outra e cansou de arrastar gigabytes por uma aba de navegador.
+- Você está consolidando arquivos entre Google Drive, OneDrive, Dropbox e S3 e quer fazer uma transferência só, não dez.
+- Você já viu um download manual travar em uma pasta maior que o espaço livre do seu notebook.
 
 ## Como vai funcionar
 
-1. Conecte o provedor de origem — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV ou Nextcloud.
-2. Conecte o provedor de destino.
-3. Pré-visualize o diff: quais arquivos serão copiados, quais já coincidem e quanto vai se mover.
-4. Escolha um runner — Cloud Runner para praticidade, Browser Runner para um caminho transparente pela sua aba, ou Private Runner no seu próprio servidor.
-5. Rode a transferência e baixe um relatório quando terminar.
+1. Conecte a origem — Google Drive, OneDrive, Dropbox, S3, SFTP, WebDAV ou Nextcloud.
+2. Conecte o destino.
+3. Rode uma prévia: quais arquivos vão ser copiados, quais já coincidem e quanto vai se mover.
+4. Confirme e rode a transferência.
+5. Baixe um relatório quando terminar.
 
 ## Por que isso é melhor do que baixar e subir de novo
 
-Transferências manuais puxam cada arquivo pelo seu notebook e empurram os mesmos bytes de volta para a nuvem. Pastas grandes falham no meio do caminho. Downloads de navegador dão timeout. Discos enchem.
+Uma transferência manual faz o caminho longo. Cada arquivo sai da nuvem de origem, aterrissa no seu notebook e sobe de volta para a nuvem de destino. Duas viagens, duas chances de falhar — e o seu disco ainda precisa ter espaço para guardar tudo no meio do caminho.
 
-Uma transferência direta entre nuvens move os bytes entre os provedores sem deixá-los na sua máquina. Você vai ver o que vai mudar antes de rodar e ter um relatório quando terminar.
+Uma transferência direta corta o meio. Os bytes vão de um provedor para o outro sem nunca passar pelo seu notebook. Você vê o que vai mudar antes de rodar e recebe um relatório quando termina.
 
-## Três formas de executar uma transferência no lançamento
-
-- **Cloud Runner.** Provedor de origem para a infraestrutura da Syncologic para o provedor de destino. Indicado para praticidade e jobs grandes que você não quer ficar acompanhando.
-- **Browser Runner.** Provedor de origem para a sua aba de navegador para o provedor de destino. A aba vai precisar ficar aberta enquanto roda. Indicado para quem quer um caminho transparente, sem nada hospedado em seu nome.
-- **Private Runner.** Provedor de origem para o seu próprio servidor, NAS ou VPS para o provedor de destino. Indicado quando bytes e credenciais precisam ficar em uma infraestrutura que você controla.
+<BeforeAfterTransfer />
 
 ## Pares de provedores comuns
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -238,7 +238,7 @@
       }
     },
     "beforeAfterTransfer": {
-      "alt": "Two stacked panels. The top panel shows the manual approach: files travel from one cloud, down through a laptop, then back up to the second cloud, with broken dashed arrows on each leg. The bottom panel shows the direct approach: a single brand-blue arc carries files from the first cloud straight to the second, bypassing the laptop entirely."
+      "alt": "Two stacked panels. The top panel shows the manual approach: files travel from one cloud, through a laptop in the middle, on to the second cloud — and every so often break at the laptop, turning red. The bottom panel shows the direct approach: a single brand-blue arc carries files from the first cloud straight to the second, bypassing the laptop entirely."
     }
   },
   "guides": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -236,6 +236,9 @@
       "runner": {
         "alt": "A single source splitting into two paths — one curving up to a hosted-server icon, one curving down to a self-hosted server icon — representing the choice between our infrastructure and your own server."
       }
+    },
+    "beforeAfterTransfer": {
+      "alt": "Two stacked panels. The top panel shows the manual approach: files travel from one cloud, down through a laptop, then back up to the second cloud, with broken dashed arrows on each leg. The bottom panel shows the direct approach: a single brand-blue arc carries files from the first cloud straight to the second, bypassing the laptop entirely."
     }
   },
   "guides": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -238,7 +238,7 @@
       }
     },
     "beforeAfterTransfer": {
-      "alt": "Dois painéis empilhados. No painel de cima, o caminho manual: os arquivos saem de uma nuvem, passam por um notebook e sobem para a segunda nuvem, com setas tracejadas e quebradas em cada perna. No painel de baixo, o caminho direto: um único arco azul leva os arquivos da primeira nuvem direto para a segunda, sem passar pelo notebook."
+      "alt": "Dois painéis empilhados. No painel de cima, o caminho manual: os arquivos saem de uma nuvem, passam por um notebook no meio e seguem para a segunda nuvem — e de vez em quando quebram no notebook, ficando vermelhos. No painel de baixo, o caminho direto: um único arco azul leva os arquivos da primeira nuvem direto para a segunda, sem passar pelo notebook."
     }
   },
   "guides": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -236,6 +236,9 @@
       "runner": {
         "alt": "Uma única origem se dividindo em dois caminhos — um subindo até um ícone de servidor hospedado, outro descendo até um ícone de servidor próprio — representando a escolha entre transferir na nossa infraestrutura ou no seu próprio servidor."
       }
+    },
+    "beforeAfterTransfer": {
+      "alt": "Dois painéis empilhados. No painel de cima, o caminho manual: os arquivos saem de uma nuvem, passam por um notebook e sobem para a segunda nuvem, com setas tracejadas e quebradas em cada perna. No painel de baixo, o caminho direto: um único arco azul leva os arquivos da primeira nuvem direto para a segunda, sem passar pelo notebook."
     }
   },
   "guides": {

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -9,6 +9,7 @@ import ProviderArc from '../../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../../components/visuals/MigrationChecklist.astro';
 import PrivateRunnerPath from '../../../components/visuals/PrivateRunnerPath.astro';
 import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
+import BeforeAfterTransfer from '../../../components/visuals/BeforeAfterTransfer.astro';
 import GuideCrossLinks from '../../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
@@ -57,7 +58,7 @@ const crossLinks = crossLinkMap[slug] ?? [];
     )}
   </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content />
+    <Content components={{ BeforeAfterTransfer }} />
   </article>
   {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -9,6 +9,7 @@ import ProviderArc from '../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../components/visuals/MigrationChecklist.astro';
 import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
 import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
+import BeforeAfterTransfer from '../../components/visuals/BeforeAfterTransfer.astro';
 import GuideCrossLinks from '../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
@@ -57,7 +58,7 @@ const crossLinks = crossLinkMap[slug] ?? [];
     )}
   </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content />
+    <Content components={{ BeforeAfterTransfer }} />
   </article>
   {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />


### PR DESCRIPTION
## Summary
- Rewrote `/use-cases/cloud-to-cloud-transfer` and `/use-cases/business-cloud-migration` (en + pt-BR) with audience-first openings and tighter sections; dropped each page's "Three ways to run a transfer" runner roll-call now that the homepage covers it.
- Added a new `BeforeAfterTransfer` visual that demonstrates the manual-via-laptop path versus the direct cloud-to-cloud arc; paired it with the "Why this beats download-and-reupload" section on cloud-to-cloud (en + pt-BR).
- Reframed the business-migration "Private Runner for sensitive moves" section so the plain-language description ("Run those transfers on a server you control") leads, with `(Private Runner)` as a parenthetical alias — matching the standing brand-term-after-description rule.

## Closes
Closes #148

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings (2 pre-existing hints unrelated to this PR).
- [x] `npm run build` — clean; all four use-case routes prerender (en + pt-BR × cloud-to-cloud + business-migration).
- [x] HTML render check on the dev server — `BeforeAfterTransfer` renders on both cloud-to-cloud pages and is correctly absent from both business-migration pages; alt label localized per locale.
- [x] `grep -nE 'Cloud Runner|Browser Runner|Private Runner|control plane|data plane'` on the four MDX files — only one hit, the business-migration "Private Runner" mention which is preceded by "a server you control" / "um servidor que você controla".
- [x] `grep -nEi 'your machine|sua máquina'` describing the Private Runner data path — none. Remaining `notebook` / `laptop` mentions describe the manual-transfer pain (intentional contrast).

## Visual verification (UI changes only)
Verified by HTML inspection on the dev server at `http://localhost:4321/use-cases/cloud-to-cloud-transfer`, `/pt-br/use-cases/cloud-to-cloud-transfer`, `/use-cases/business-cloud-migration`, and `/pt-br/use-cases/business-cloud-migration`. Cross-breakpoint browser verification (375 / 768 / 1024 / 1440) and `prefers-reduced-motion` check are pending — recommend a quick spot-check before merge.

## Notes
- No dependency changes.
- The new visual ships with translatable `alt` under `visuals.beforeAfterTransfer.alt` in both `src/i18n/en.json` and `src/i18n/pt-br.json`. Inner SVG decoration is `aria-hidden`.
- The use-case template at `src/pages/{,pt-br/}use-cases/[slug].astro` now passes a `components` map to `<Content />`, exposing `BeforeAfterTransfer` to MDX. Adding more visuals later is a one-line change.
