### PR TITLE
Self-hosted page: three-layer rewrite with PrivateRunnerPath in the hero and technical detail in a collapsible block

### DIFF
--- a/src/components/sections/SelfHostedSections.astro
+++ b/src/components/sections/SelfHostedSections.astro
@@ -1,67 +1,35 @@
 ---
+import { ChevronDown } from '@lucide/astro';
 import Section from '../ui/Section.astro';
 import Card from '../ui/Card.astro';
+import ControlDataPlanes from '../visuals/ControlDataPlanes.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 
-const principles = [
-  { key: 'controlPlane' },
-  { key: 'dataPlane' },
-] as const;
-
-const privateRunnerPoints = ['outbound', 'credentials', 'dataPath'] as const;
-
-const futureLevels = ['level1', 'level2', 'level3'] as const;
+const howItWorksCards = ['filesStay', 'credentials', 'noInbound'] as const;
+const roadmapLevels = ['level1', 'level2'] as const;
 ---
 
-<Section surface="soft" padding="lg" id="principles">
+<Section surface="white" padding="lg" id="how-it-works">
   <div class="max-w-[760px] mb-12">
     <h2 class="text-h1 font-medium text-dark-charcoal mb-4">
-      {t('selfHosted.principles.title')}
+      {t('selfHosted.howItWorks.title')}
     </h2>
     <p class="text-body text-slate-gray">
-      {t('selfHosted.principles.intro')}
-    </p>
-  </div>
-
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-    {principles.map((p) => (
-      <Card radius="card" elevation="flat" class="p-8">
-        <h3 class="text-h3 font-bold text-dark-charcoal mb-3">
-          {t(`selfHosted.principles.${p.key}.title`)}
-        </h3>
-        <p class="text-body text-slate-gray">
-          {t(`selfHosted.principles.${p.key}.desc`)}
-        </p>
-      </Card>
-    ))}
-  </div>
-
-  <p class="text-caption text-slate-gray max-w-[760px]">
-    {t('selfHosted.principles.note')}
-  </p>
-</Section>
-
-<Section surface="white" padding="lg">
-  <div class="max-w-[760px] mb-12">
-    <h2 class="text-h1 font-medium text-dark-charcoal mb-4">
-      {t('selfHosted.privateRunner.title')}
-    </h2>
-    <p class="text-body text-slate-gray">
-      {t('selfHosted.privateRunner.body')}
+      {t('selfHosted.howItWorks.intro')}
     </p>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-    {privateRunnerPoints.map((p) => (
-      <Card radius="card" elevation="flat" class="p-6">
-        <h3 class="text-h3 font-bold text-dark-charcoal mb-2">
-          {t(`selfHosted.privateRunner.${p}.title`)}
+    {howItWorksCards.map((key) => (
+      <Card radius="card" elevation="flat" class="p-8">
+        <h3 class="text-h3 font-bold text-dark-charcoal mb-3">
+          {t(`selfHosted.howItWorks.${key}.title`)}
         </h3>
         <p class="text-body text-slate-gray">
-          {t(`selfHosted.privateRunner.${p}.desc`)}
+          {t(`selfHosted.howItWorks.${key}.desc`)}
         </p>
       </Card>
     ))}
@@ -69,49 +37,75 @@ const futureLevels = ['level1', 'level2', 'level3'] as const;
 </Section>
 
 <Section surface="soft" padding="lg">
-  <div class="max-w-[760px] mb-12">
-    <div class="flex flex-wrap items-center gap-3 mb-4">
-      <h2 class="text-h1 font-medium text-dark-charcoal">
-        {t('selfHosted.futureModel.title')}
-      </h2>
-      <span class="inline-flex items-center rounded-pill bg-baby-blue text-dark-charcoal text-caption font-medium px-3 py-1">
-        {t('selfHosted.futureModel.label')}
-      </span>
-    </div>
-    <p class="text-body text-slate-gray">
-      {t('selfHosted.futureModel.intro')}
-    </p>
-  </div>
+  <details class="group max-w-[1040px] mx-auto self-hosted-details">
+    <summary class="flex items-center justify-between gap-4 cursor-pointer rounded-card bg-white border border-divider px-6 py-5 text-h3 font-bold text-dark-charcoal hover:border-slate-gray transition-colors">
+      <span>{t('selfHosted.underTheHood.summary')}</span>
+      <ChevronDown size={20} class="shrink-0 transition-transform duration-200 group-open:rotate-180 text-slate-gray" />
+    </summary>
 
-  <ol class="grid grid-cols-1 md:grid-cols-3 gap-6 list-none">
-    {futureLevels.map((lvl, i) => (
-      <li>
-        <Card radius="card" elevation="flat" class="p-6 h-full flex flex-col gap-3">
-          <span class="text-caption font-medium text-slate-gray uppercase tracking-wide">
-            {String(i + 1).padStart(2, '0')}
-          </span>
+    <div class="mt-8 flex flex-col gap-12">
+      <p class="text-body text-slate-gray max-w-[760px]">
+        {t('selfHosted.underTheHood.intro')}
+      </p>
+
+      <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,520px)] gap-10 items-center">
+        <div class="flex flex-col gap-4">
           <h3 class="text-h3 font-bold text-dark-charcoal">
-            {t(`selfHosted.futureModel.${lvl}.name`)}
+            {t('selfHosted.underTheHood.controlData.title')}
           </h3>
-          <span class="inline-flex self-start items-center rounded-pill border border-divider text-caption text-slate-gray px-3 py-1">
-            {t(`selfHosted.futureModel.${lvl}.status`)}
-          </span>
           <p class="text-body text-slate-gray">
-            {t(`selfHosted.futureModel.${lvl}.desc`)}
+            {t('selfHosted.underTheHood.controlData.body')}
           </p>
-        </Card>
-      </li>
-    ))}
-  </ol>
+        </div>
+        <ControlDataPlanes />
+      </div>
+
+      <div>
+        <h3 class="text-h3 font-bold text-dark-charcoal mb-6">
+          {t('selfHosted.underTheHood.roadmap.title')}
+        </h3>
+        <ol class="grid grid-cols-1 md:grid-cols-2 gap-6 list-none">
+          {roadmapLevels.map((lvl, i) => (
+            <li>
+              <Card radius="card" elevation="flat" class="p-6 h-full flex flex-col gap-3 bg-white">
+                <span class="text-caption font-medium text-slate-gray uppercase tracking-wide">
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <h4 class="text-h3 font-bold text-dark-charcoal">
+                  {t(`selfHosted.underTheHood.roadmap.${lvl}.name`)}
+                </h4>
+                <span class="inline-flex self-start items-center rounded-pill border border-divider text-caption text-slate-gray px-3 py-1">
+                  {t(`selfHosted.underTheHood.roadmap.${lvl}.status`)}
+                </span>
+                <p class="text-body text-slate-gray">
+                  {t(`selfHosted.underTheHood.roadmap.${lvl}.desc`)}
+                </p>
+              </Card>
+            </li>
+          ))}
+        </ol>
+        <p class="text-caption text-slate-gray mt-4 max-w-[760px]">
+          {t('selfHosted.underTheHood.roadmap.footnote')}
+        </p>
+      </div>
+
+      <div class="max-w-[760px]">
+        <h3 class="text-h3 font-bold text-dark-charcoal mb-3">
+          {t('selfHosted.underTheHood.sourceVisible.title')}
+        </h3>
+        <p class="text-body text-slate-gray">
+          {t('selfHosted.underTheHood.sourceVisible.body')}
+        </p>
+      </div>
+    </div>
+  </details>
 </Section>
 
-<Section surface="dark" padding="lg">
-  <div class="max-w-[760px] flex flex-col gap-5">
-    <h2 class="text-h1 font-medium text-white">
-      {t('selfHosted.sourceTrust.title')}
-    </h2>
-    <p class="text-body text-white/80">
-      {t('selfHosted.sourceTrust.body')}
-    </p>
-  </div>
-</Section>
+<style>
+  .self-hosted-details summary {
+    list-style: none;
+  }
+  .self-hosted-details summary::-webkit-details-marker {
+    display: none;
+  }
+</style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -498,69 +498,58 @@
   },
   "selfHosted": {
     "meta": {
-      "title": "Self-hosted future — Syncologic",
-      "description": "Source-visible, self-hostable cloud file transfer. Private Runner first, then full self-host, then air-gapped — on your timeline."
+      "title": "Run transfers on your own server — Syncologic",
+      "description": "Move files between clouds with the data path running entirely on your own server, NAS, or VPS. Files never pass through our infrastructure."
     },
     "hero": {
-      "eyebrow": "Self-hosted future",
-      "headline": "Source-visible. Self-hostable. Yours to run.",
-      "subheading": "Source-visible runner at launch. Self-hostable control plane on the roadmap.",
+      "eyebrow": "On your own server",
+      "headline": "Run everything on your own server.",
+      "subheading": "Files never pass through our infrastructure. You install a small program, connect your clouds to it, and the transfer runs inside your network.",
       "audience": "For homelab operators, privacy-conscious users, and businesses that want their file transfers running on infrastructure they control.",
       "primaryCta": "Join the waitlist",
-      "secondaryCta": "See the principles"
+      "secondaryCta": "How it works"
     },
-    "principles": {
-      "title": "Architecture principles",
-      "intro": "We separate the metadata layer from where files actually move. That split is what makes self-hosting tractable.",
-      "controlPlane": {
-        "title": "Control plane",
-        "desc": "Accounts, jobs, schedules, reports. The metadata layer — hosted by us at launch, self-hostable on the roadmap."
-      },
-      "dataPlane": {
-        "title": "Data plane",
-        "desc": "Where bytes flow. Source → runner → destination. Self-host the runner from launch; bytes never reach the control plane."
-      },
-      "note": "Files do not flow through our server. The server holds metadata; the runner moves the bytes."
-    },
-    "privateRunner": {
-      "title": "Private Runner: available first",
-      "body": "Run transfers on your own server, NAS, or VPS at launch. Your provider credentials and file bytes stay with you; the control plane only holds job metadata.",
-      "outbound": {
-        "title": "Outbound only",
-        "desc": "Your runner reaches out to us. No inbound ports, no exposed services."
+    "howItWorks": {
+      "title": "How it works for you",
+      "intro": "You run the transfer on your own server. We coordinate the job; the bytes never reach us. We call this setup a Private Runner.",
+      "filesStay": {
+        "title": "Files never park on our servers",
+        "desc": "Bytes travel from the source cloud, through your server, to the destination cloud. Our infrastructure never sees the files."
       },
       "credentials": {
-        "title": "Credentials stay with you",
-        "desc": "Provider tokens live where your runner runs. We never see them."
+        "title": "Your credentials stay with you",
+        "desc": "Provider tokens live where your runner runs. We never receive them."
       },
-      "dataPath": {
-        "title": "Direct data path",
-        "desc": "Files flow source → your runner → destination. Nothing in between."
+      "noInbound": {
+        "title": "No incoming connections to open",
+        "desc": "Your server reaches out to us. No firewall holes, no exposed services, no port-forwarding."
       }
     },
-    "futureModel": {
-      "title": "Future self-host levels",
-      "label": "On the roadmap",
-      "intro": "Three levels of self-hosting, in increasing independence from our infrastructure.",
-      "level1": {
-        "name": "Private Runner",
-        "status": "Available first",
-        "desc": "Hosted control plane, your data path. For users who want our convenience and your bandwidth."
+    "underTheHood": {
+      "summary": "How it works under the hood",
+      "intro": "Architecture, the self-host roadmap, and why core code stays public — for the technical buyer.",
+      "controlData": {
+        "title": "Control plane vs data plane",
+        "body": "Two layers. The control plane (auth, jobs, schedules, reports) holds metadata about your transfers. The data plane (the runner) is where bytes flow source → destination. We host the control plane at launch; you host the data plane from day one."
       },
-      "level2": {
-        "name": "Full self-host",
-        "status": "Planned",
-        "desc": "Bring your own control plane. Your auth, your database, your runners. Same product, your infrastructure."
+      "roadmap": {
+        "title": "Self-host levels",
+        "level1": {
+          "name": "Private Runner",
+          "status": "Available first",
+          "desc": "Hosted control plane, your data path. For users who want our convenience and your bandwidth."
+        },
+        "level2": {
+          "name": "Full self-host",
+          "status": "Planned",
+          "desc": "Bring your own control plane. Your auth, your database, your runners. Same product, your infrastructure."
+        },
+        "footnote": "Plus an air-gapped variant for high-compliance environments that can't reach the public internet."
       },
-      "level3": {
-        "name": "Air-gapped",
-        "status": "Planned",
-        "desc": "No outbound dependency on syncologic.com. For high-compliance environments that can't reach the public internet."
+      "sourceVisible": {
+        "title": "Why core code stays public",
+        "body": "Runner code, transfer logic, and provider adapters ship source-visible. You can audit how files move before trusting the system."
       }
-    },
-    "sourceTrust": {
-      "title": "Why core code stays public",
-      "body": "Runner code, transfer logic, and provider adapters will ship source-visible. You'll be able to audit how files move before trusting the system."
     }
   }
 }

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -498,69 +498,58 @@
   },
   "selfHosted": {
     "meta": {
-      "title": "O futuro da auto-hospedagem — Syncologic",
-      "description": "Transferência de arquivos entre nuvens com código visível e auto-hospedável. Private Runner primeiro, depois auto-hospedagem completa, depois air-gapped — no seu tempo."
+      "title": "Rode transferências no seu próprio servidor — Syncologic",
+      "description": "Mova arquivos entre nuvens com o caminho de dados rodando inteiramente no seu próprio servidor, NAS ou VPS. Os arquivos nunca passam pela nossa infraestrutura."
     },
     "hero": {
-      "eyebrow": "O futuro da auto-hospedagem",
-      "headline": "Código visível. Auto-hospedável. Sob seu controle.",
-      "subheading": "Runner com código visível no lançamento. Camada de controle auto-hospedável no roadmap.",
+      "eyebrow": "No seu próprio servidor",
+      "headline": "Rode tudo no seu próprio servidor.",
+      "subheading": "Os arquivos nunca passam pela nossa infraestrutura. Você instala um pequeno programa, conecta as suas nuvens nele, e a transferência roda dentro da sua rede.",
       "audience": "Para usuários de homelab, pessoas que se importam com privacidade e empresas que querem rodar transferências de arquivos em uma infraestrutura que elas controlam.",
       "primaryCta": "Entrar na lista de espera",
-      "secondaryCta": "Ver os princípios"
+      "secondaryCta": "Como funciona"
     },
-    "principles": {
-      "title": "Princípios de arquitetura",
-      "intro": "Separamos a camada de metadados de onde os arquivos realmente trafegam. Essa divisão é o que torna a auto-hospedagem viável.",
-      "controlPlane": {
-        "title": "Camada de controle",
-        "desc": "Contas, jobs, agendamentos, relatórios. A camada de metadados — hospedada por nós no lançamento, auto-hospedável no roadmap."
-      },
-      "dataPlane": {
-        "title": "Camada de dados",
-        "desc": "Onde os bytes fluem. Origem → runner → destino. O runner é auto-hospedável desde o lançamento; os bytes nunca chegam à camada de controle."
-      },
-      "note": "Os arquivos não passam pelo nosso servidor. O servidor guarda metadados; o runner é quem move os bytes."
-    },
-    "privateRunner": {
-      "title": "Private Runner: vem primeiro",
-      "body": "Rode transferências no seu próprio servidor, NAS ou VPS desde o lançamento. Suas credenciais de provedor e os bytes dos arquivos ficam com você; a camada de controle guarda apenas metadados dos jobs.",
-      "outbound": {
-        "title": "Apenas saída",
-        "desc": "Seu runner é quem se conecta com a gente. Sem portas de entrada, sem serviços expostos."
+    "howItWorks": {
+      "title": "Como funciona para você",
+      "intro": "Você roda a transferência no seu próprio servidor. A gente coordena o job; os bytes nunca chegam até a gente. A gente chama essa configuração de Private Runner.",
+      "filesStay": {
+        "title": "Os arquivos nunca passam pelos nossos servidores",
+        "desc": "Os bytes saem da nuvem de origem, passam pelo seu servidor e chegam à nuvem de destino. A nossa infraestrutura nunca vê os arquivos."
       },
       "credentials": {
-        "title": "As credenciais ficam com você",
-        "desc": "Os tokens de provedor ficam onde o seu runner roda. A gente nunca vê."
+        "title": "As suas credenciais ficam com você",
+        "desc": "Os tokens de provedor ficam onde o seu runner roda. A gente nunca recebe."
       },
-      "dataPath": {
-        "title": "Caminho de dados direto",
-        "desc": "Os arquivos fluem da origem → seu runner → destino. Nada no meio."
+      "noInbound": {
+        "title": "Sem conexões de entrada para abrir",
+        "desc": "O seu servidor é quem se conecta com a gente. Sem buracos no firewall, sem serviços expostos, sem encaminhamento de porta."
       }
     },
-    "futureModel": {
-      "title": "Níveis futuros de auto-hospedagem",
-      "label": "No roadmap",
-      "intro": "Três níveis de auto-hospedagem, em ordem crescente de independência da nossa infraestrutura.",
-      "level1": {
-        "name": "Private Runner",
-        "status": "Vem primeiro",
-        "desc": "Camada de controle hospedada, caminho de dados seu. Para quem quer a nossa praticidade e a sua banda."
+    "underTheHood": {
+      "summary": "Como funciona por baixo dos panos",
+      "intro": "Arquitetura, o roadmap de auto-hospedagem e por que o código principal fica público — para o comprador técnico.",
+      "controlData": {
+        "title": "Camada de controle e camada de dados",
+        "body": "Duas camadas. A camada de controle (autenticação, jobs, agendamentos, relatórios) guarda metadados sobre as suas transferências. A camada de dados (o runner) é por onde os bytes trafegam de origem → destino. A gente hospeda a camada de controle no lançamento; você hospeda a camada de dados desde o primeiro dia."
       },
-      "level2": {
-        "name": "Auto-hospedagem completa",
-        "status": "Planejado",
-        "desc": "Traga a sua própria camada de controle. Sua autenticação, seu banco de dados, seus runners. Mesmo produto, sua infraestrutura."
+      "roadmap": {
+        "title": "Níveis de auto-hospedagem",
+        "level1": {
+          "name": "Private Runner",
+          "status": "Vem primeiro",
+          "desc": "Camada de controle hospedada, caminho de dados seu. Para quem quer a nossa praticidade com a sua banda."
+        },
+        "level2": {
+          "name": "Auto-hospedagem completa",
+          "status": "Planejado",
+          "desc": "Traga a sua própria camada de controle. Sua autenticação, seu banco de dados, seus runners. Mesmo produto, sua infraestrutura."
+        },
+        "footnote": "Mais uma variante air-gapped para ambientes de alta conformidade que não acessam a internet pública."
       },
-      "level3": {
-        "name": "Air-gapped",
-        "status": "Planejado",
-        "desc": "Sem dependência de saída de syncologic.com. Para ambientes de alta conformidade que não acessam a internet pública."
+      "sourceVisible": {
+        "title": "Por que o código principal fica público",
+        "body": "O código do runner, a lógica de transferência e os adaptadores de provedor são lançados com código visível. Você pode auditar como os arquivos trafegam antes de confiar no sistema."
       }
-    },
-    "sourceTrust": {
-      "title": "Por que o código principal fica público",
-      "body": "O código do runner, a lógica de transferência e os adaptadores de provedor serão lançados com código visível. Você vai poder auditar como os arquivos trafegam antes de confiar no sistema."
     }
   }
 }

--- a/src/pages/pt-br/self-hosted.astro
+++ b/src/pages/pt-br/self-hosted.astro
@@ -5,7 +5,7 @@ import Footer from '../../components/layout/Footer.astro';
 import Hero from '../../components/sections/Hero.astro';
 import SelfHostedSections from '../../components/sections/SelfHostedSections.astro';
 import WaitlistForm from '../../components/sections/WaitlistForm.astro';
-import ControlDataPlanes from '../../components/visuals/ControlDataPlanes.astro';
+import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
 import { getLocaleFromUrl, getT } from '../../i18n/utils';
 
 const locale = getLocaleFromUrl(Astro.url);
@@ -20,13 +20,13 @@ const t = getT(locale);
       headline={t('selfHosted.hero.headline')}
       subheading={t('selfHosted.hero.subheading')}
       primaryCta={{ label: t('selfHosted.hero.primaryCta'), href: '#waitlist' }}
-      secondaryCta={{ label: t('selfHosted.hero.secondaryCta'), href: '#principles' }}
+      secondaryCta={{ label: t('selfHosted.hero.secondaryCta'), href: '#how-it-works' }}
     >
       <p slot="meta" class="text-caption text-slate-gray max-w-[640px]">
         {t('selfHosted.hero.audience')}
       </p>
       <Fragment slot="visual">
-        <ControlDataPlanes />
+        <PrivateRunnerPath />
       </Fragment>
     </Hero>
   </div>

--- a/src/pages/self-hosted.astro
+++ b/src/pages/self-hosted.astro
@@ -5,7 +5,7 @@ import Footer from '../components/layout/Footer.astro';
 import Hero from '../components/sections/Hero.astro';
 import SelfHostedSections from '../components/sections/SelfHostedSections.astro';
 import WaitlistForm from '../components/sections/WaitlistForm.astro';
-import ControlDataPlanes from '../components/visuals/ControlDataPlanes.astro';
+import PrivateRunnerPath from '../components/visuals/PrivateRunnerPath.astro';
 import { getLocaleFromUrl, getT } from '../i18n/utils';
 
 const locale = getLocaleFromUrl(Astro.url);
@@ -20,13 +20,13 @@ const t = getT(locale);
       headline={t('selfHosted.hero.headline')}
       subheading={t('selfHosted.hero.subheading')}
       primaryCta={{ label: t('selfHosted.hero.primaryCta'), href: '#waitlist' }}
-      secondaryCta={{ label: t('selfHosted.hero.secondaryCta'), href: '#principles' }}
+      secondaryCta={{ label: t('selfHosted.hero.secondaryCta'), href: '#how-it-works' }}
     >
       <p slot="meta" class="text-caption text-slate-gray max-w-[640px]">
         {t('selfHosted.hero.audience')}
       </p>
       <Fragment slot="visual">
-        <ControlDataPlanes />
+        <PrivateRunnerPath />
       </Fragment>
     </Hero>
   </div>


### PR DESCRIPTION
## Summary
- Rewrote `/self-hosted` (en + pt-BR) into three layers: a plain-language hero ("Run everything on your own server."), a workflow-level "How it works for you" section with three plain-titled cards naming the brand alias once, and a collapsible `<details>` block containing the technical content (control plane vs data plane with `ControlDataPlanes`, the Private Runner / Full self-host roadmap pair, the source-visible paragraph).
- Swapped the hero visual from `ControlDataPlanes` to `PrivateRunnerPath` — the trust-story visual now leads, and the architecture diagram lives where it belongs (next to the architecture explanation, inside the collapsible).
- Air-gapped is no longer its own roadmap card; it's now a single `text-caption` footnote under the two-up roadmap pair.
- Dropped the standalone dark "Why core code stays public" section. Its single useful sentence now lives at the bottom of the collapsible.

## Closes
Closes #150

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings (2 pre-existing hints, unrelated).
- [x] `npm run build` — clean. `/self-hosted` and `/pt-br/self-hosted` both prerender; both visuals render with the right localized alt strings.
- [x] HTML render check on dev server — H1 is "Run everything on your own server." / "Rode tudo no seu próprio servidor." in their respective locales; H2 layer-2 sections are "How it works for you" / "Como funciona para você"; `<details>` summary contains "How it works under the hood" / "Como funciona por baixo dos panos".
- [x] Layer-1 jargon audit on `selfHosted.{meta,hero,howItWorks}` (en + pt-BR): zero hits for "control plane", "data plane", "self-host", "source-visible", "air-gapp". Brand alias "Private Runner" / "código visível" only appear after a plain-language description, in the same paragraph.
- [x] No stale references to the removed `selfHosted.{principles,privateRunner,futureModel,sourceTrust}` keys.

## Visual verification (UI changes only)
Verified by HTML inspection on the dev server — `PrivateRunnerPath` renders in the hero, `ControlDataPlanes` renders inside the `<details>` block, both localize per locale. Cross-breakpoint browser verification (375 / 768 / 1024 / 1440) and `<details>` keyboard-toggle / focus ring check are pending — recommend a quick spot-check before merge.

## Notes
- No dependency changes.
- The collapsible is HTML-native `<details>` with a custom rotating chevron from `@lucide/astro` — zero client JS, keyboard-reachable for free. Default-marker hidden via a small scoped `<style>` block (`list-style: none` + `::-webkit-details-marker { display: none }`).
- This page is now linked from `/use-cases/business-cloud-migration`'s "Keep sensitive data on your own server" section. The new layer-1 hero answers exactly the question that referral implies, without forcing brand vocabulary on a reader who doesn't know runner taxonomy yet.