### PR TITLE
Use-case rewrite (2/2): private-runner + scheduled-cloud-backup

### DIFF
--- a/src/components/visuals/HostedVsPrivatePath.astro
+++ b/src/components/visuals/HostedVsPrivatePath.astro
@@ -1,0 +1,197 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const altLabel = t('visuals.hostedVsPrivatePath.alt');
+const hostedLabel = t('visuals.hostedVsPrivatePath.hostedLabel');
+const privateLabel = t('visuals.hostedVsPrivatePath.privateLabel');
+---
+
+<div class="hosted-vs-private w-full max-w-[480px] mx-auto" role="presentation">
+  <svg
+    viewBox="0 0 480 310"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label={altLabel}
+    class="w-full h-auto block"
+  >
+    <g aria-hidden="true">
+      <rect x="20" y="40" width="80" height="60" rx="14" class="fill-soft-gray" />
+      <path
+        d="M 36 78 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 42 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-slate-gray"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="170" y="45" width="140" height="50" rx="12" class="fill-warm-gray stroke-slate-gray" stroke-width="1" />
+      <g transform="translate(186 60)" class="stroke-slate-gray" stroke-width="1.2" stroke-linecap="round" fill="none">
+        <rect x="0" y="0" width="20" height="9" rx="2" />
+        <rect x="0" y="13" width="20" height="9" rx="2" />
+        <circle cx="4" cy="4.5" r="1" class="fill-slate-gray stroke-none" />
+        <circle cx="4" cy="17.5" r="1" class="fill-slate-gray stroke-none" />
+        <line x1="9" y1="4.5" x2="16" y2="4.5" />
+        <line x1="9" y1="17.5" x2="16" y2="17.5" />
+      </g>
+      <text x="216" y="74" class="box-label fill-dark-charcoal">{hostedLabel}</text>
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="380" y="40" width="80" height="60" rx="14" class="fill-soft-gray" />
+      <path
+        d="M 396 78 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 402 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-slate-gray"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <path
+      d="M 100 70 L 170 70"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="stroke-brand-blue"
+      aria-hidden="true"
+    />
+    <path
+      d="M 310 70 L 380 70"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="stroke-brand-blue"
+      aria-hidden="true"
+    />
+
+    <g class="hosted-pills" aria-hidden="true">
+      <g class="hosted-pill hosted-pill-a">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+      </g>
+      <g class="hosted-pill hosted-pill-b">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+      </g>
+    </g>
+
+    <line
+      x1="40" y1="155" x2="440" y2="155"
+      class="stroke-divider"
+      stroke-width="1"
+      stroke-dasharray="4 6"
+      aria-hidden="true"
+    />
+
+    <g aria-hidden="true">
+      <rect x="20" y="200" width="80" height="60" rx="14" class="fill-soft-gray" />
+      <path
+        d="M 36 238 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 42 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-slate-gray"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="170" y="205" width="140" height="50" rx="12" class="fill-white stroke-slate-gray" stroke-width="1" />
+      <g transform="translate(186 220)" class="stroke-slate-gray" stroke-width="1.2" stroke-linecap="round" fill="none">
+        <rect x="0" y="0" width="20" height="9" rx="2" />
+        <rect x="0" y="13" width="20" height="9" rx="2" />
+        <circle cx="4" cy="4.5" r="1" class="fill-slate-gray stroke-none" />
+        <circle cx="4" cy="17.5" r="1" class="fill-slate-gray stroke-none" />
+        <line x1="9" y1="4.5" x2="16" y2="4.5" />
+        <line x1="9" y1="17.5" x2="16" y2="17.5" />
+      </g>
+      <text x="216" y="234" class="box-label fill-dark-charcoal">{privateLabel}</text>
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="380" y="200" width="80" height="60" rx="14" class="fill-soft-gray" />
+      <path
+        d="M 396 238 a 10 10 0 0 1 10 -10 a 14 14 0 0 1 26 4 a 8 8 0 0 1 0 16 H 402 a 8 8 0 0 1 -6 -10 z"
+        class="fill-white stroke-slate-gray"
+        stroke-width="1.2"
+      />
+    </g>
+
+    <path
+      d="M 100 230 L 170 230"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="stroke-brand-blue"
+      aria-hidden="true"
+    />
+    <path
+      d="M 310 230 L 380 230"
+      fill="none"
+      stroke-width="1.5"
+      stroke-dasharray="2 6"
+      stroke-linecap="round"
+      class="stroke-brand-blue"
+      aria-hidden="true"
+    />
+
+    <g class="private-pills" aria-hidden="true">
+      <g class="private-pill private-pill-a">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+      </g>
+      <g class="private-pill private-pill-b">
+        <rect x="-22" y="-10" width="44" height="20" rx="10" class="fill-white stroke-brand-blue" stroke-width="1" />
+        <line x1="-12" y1="-3" x2="10" y2="-3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+        <line x1="-12" y1="3" x2="4" y2="3" stroke-width="1.5" stroke-linecap="round" class="stroke-brand-blue" />
+      </g>
+    </g>
+  </svg>
+</div>
+
+<style>
+  .hosted-vs-private { min-width: 280px; }
+
+  .box-label {
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+
+  .hosted-pill,
+  .private-pill {
+    offset-rotate: 0deg;
+    offset-distance: 0%;
+    opacity: 0;
+  }
+  .hosted-pill {
+    offset-path: path('M 100 70 L 380 70');
+  }
+  .private-pill {
+    offset-path: path('M 100 230 L 380 230');
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .hosted-pill-a  { animation: hvp-pill-travel 4s linear infinite; }
+    .hosted-pill-b  { animation: hvp-pill-travel 4s linear infinite 2s; }
+    .private-pill-a { animation: hvp-pill-travel 4s linear infinite 1s; }
+    .private-pill-b { animation: hvp-pill-travel 4s linear infinite 3s; }
+
+    @keyframes hvp-pill-travel {
+      0%   { offset-distance: 0%;   opacity: 0; }
+      8%   { offset-distance: 4%;   opacity: 1; }
+      92%  { offset-distance: 96%;  opacity: 1; }
+      100% { offset-distance: 100%; opacity: 0; }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hosted-pill-a  { offset-distance: 35%; opacity: 1; }
+    .hosted-pill-b  { offset-distance: 65%; opacity: 1; }
+    .private-pill-a { offset-distance: 35%; opacity: 1; }
+    .private-pill-b { offset-distance: 65%; opacity: 1; }
+  }
+</style>

--- a/src/content/use-cases/en/private-runner.mdx
+++ b/src/content/use-cases/en/private-runner.mdx
@@ -4,7 +4,7 @@ title: "Private Runner — transfer files on your own infrastructure"
 description: "Run cloud-to-cloud transfers through your own server, NAS, or VPS. Bytes and credentials stay in infrastructure you control."
 eyebrow: "For privacy, homelabs, and businesses with sensitive data"
 headline: "Run transfers on your own server, NAS, or VPS."
-subheading: "Hosted control plane, your data path. Bytes and credentials stay on infrastructure you control."
+subheading: "Files never pass through our infrastructure. The transfer runs on a server you own, between the source and destination clouds."
 primaryCta:
   label: "Join the waitlist"
   href: "#waitlist"
@@ -17,68 +17,55 @@ publishedAt: 2026-05-01
 
 ## Who this is for
 
-- Privacy-conscious users who want a hosted control plane but not a hosted data plane.
-- Small businesses with sensitive data — legal archives, financial records, regulated content — that shouldn't pass through anyone else's infrastructure.
-- Homelab operators with an always-on server, NAS, or VPS already built for jobs like this.
-- High-volume users who'd rather pay for software and bring their own bandwidth than rent throughput.
-
-## The data path
-
-The Cloud Runner sends bytes through Syncologic infrastructure. The Private Runner doesn't.
-
-`Source provider` → `Your Private Runner` → `Destination provider`
-
-Files flow directly from the source API to the runner you operate, then to the destination. The control plane sees what the job is and when it ran — never the file contents, never long-lived credentials.
-
-## Outbound connection only
-
-You don't open a port. The runner makes an outbound connection to the control plane and waits for work. When a job is dispatched, it pulls a short-lived run lease, runs the transfer, and posts progress events back.
-
-That means:
-
-- No inbound firewall rules.
-- No public IP requirement.
-- No reverse proxy or tunnel.
-- Works behind home NAT, behind a corporate proxy, behind anything that allows outbound HTTPS.
+- You don't want anyone else's infrastructure in the path your files take.
+- You handle sensitive material — legal archives, financial records, regulated content — that shouldn't pass through someone else's servers.
+- You already keep an always-on server, NAS, or VPS running for jobs like this.
+- You move enough volume that bringing your own bandwidth costs less than renting throughput.
 
 ## How it'll work
 
 1. Install the runner on hardware you control — a NAS, a VPS, an always-on Linux box, or a Raspberry Pi that stays on.
 2. Pair it with your Syncologic account using a one-time enrolment code.
-3. Connect your source and destination providers from the control plane like normal.
-4. When you dispatch a job, pick the Private Runner instead of the Cloud Runner.
+3. Connect your source and destination providers from the dashboard.
+4. When you start a job, pick the runner you just paired instead of the hosted option.
 5. The runner pulls the work, transfers the files between provider APIs, and reports back when it's done.
+
+The hero diagram up top shows the path. Files flow direct from the source API to your runner, then to the destination. We see what the job is and when it ran — never the file contents.
+
+## No firewall changes on your side
+
+Works behind home NAT, behind a corporate proxy, behind anything that allows outbound HTTPS. You don't open a port. The runner makes an outbound connection to us and waits for work; when a job is dispatched, it pulls a short-lived run lease, runs the transfer, and posts progress back.
+
+No inbound firewall rules. No public IP. No reverse proxy. No tunnel.
 
 ## Where you'd run it
 
-The runner is small enough to live next to other lightweight services on hardware you already own.
+The runner is small enough to live next to other lightweight services on hardware you already own — a Synology, QNAP, or TrueNAS box that's already on 24/7, a homelab Linux server or mini-PC, a small VPS (Hetzner, Fly, DigitalOcean, OVH), an always-on workstation acting as a small home server, or a Raspberry Pi class device for slower, low-throughput backups.
 
-- A Synology, QNAP, or TrueNAS box that's already on 24/7.
-- A homelab Linux server or mini-PC running other long-lived jobs.
-- A small VPS — Hetzner, Fly, DigitalOcean, OVH — for users who want it off-prem but still under their account.
-- An always-on workstation acting as a small home server, for one-time migrations.
-- A Raspberry Pi class device for slower, low-throughput backups.
+It cares about reliable network and enough disk for staging buffers; it doesn't care which distro or hardware you picked.
 
-The runner cares about reliable network and enough disk for staging buffers; it doesn't care which distro or hardware you picked.
+## Your credentials stay with you
 
-## Credential handling
+Provider OAuth tokens will be bound to the runner — encrypted at rest with a key derived from your enrolment, never leaving the runner. We see provider identifiers, scopes, and run metadata; never refresh tokens, never file contents.
 
-Provider OAuth tokens will be bound to the runner — encrypted at rest with a key derived from your enrolment, never leaving the runner. The control plane sees provider identifiers, scopes, and run metadata; never refresh tokens, never file contents.
+Decommission the runner and revoke its enrolment from the dashboard — the tokens it held become useless.
 
-Decommission the runner and revoke its enrolment from the control plane — the tokens it held will become useless.
+## Hosted versus your own server
 
-## Cloud Runner vs Private Runner
+<PricingCurves />
 
-### Cloud Runner
+Both modes use the same dashboard, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow — and what that means for cost and trust.
 
-- **Where bytes flow:** source → Syncologic infrastructure → destination.
+### On our servers (Cloud Runner)
+
+- **Where bytes flow:** source → our infrastructure → destination.
 - **Where credentials live:** encrypted in our infrastructure, short-lived.
 - **Setup effort:** none — pick it from the dropdown.
 - **Best for:** convenience, very large jobs you don't want to host yourself.
 - **Pricing model:** usage-based on our infrastructure.
 - **Network requirements:** none.
 
-### Private Runner
+### On your own server (Private Runner)
 
 - **Where bytes flow:** source → your server → destination.
 - **Where credentials live:** on your runner, never leaves.
@@ -87,10 +74,8 @@ Decommission the runner and revoke its enrolment from the control plane — the 
 - **Pricing model:** pay for software; you bring bandwidth.
 - **Network requirements:** outbound HTTPS from the runner.
 
-Both runners use the same control plane, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow.
+## Public source code
 
-## Public source and a future self-host path
-
-The runner will work against our hosted control plane at launch, and against a self-hosted control plane later. The core code will ship source-visible — you can audit it before installing. Self-host of the control plane is a separate, longer track; Private Runner is the first step.
+You can audit how the runner moves files before installing it — the code is public. We plan to keep that property as we grow.
 
 Where would you run your Private Runner — NAS, homelab server, VPS, or workstation? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/content/use-cases/en/private-runner.mdx
+++ b/src/content/use-cases/en/private-runner.mdx
@@ -52,7 +52,7 @@ Decommission the runner and revoke its enrolment from the dashboard — the toke
 
 ## Hosted versus your own server
 
-<PricingCurves />
+<HostedVsPrivatePath />
 
 Both modes use the same dashboard, the same job definitions, the same preview, and the same completion reports. The only difference is where the bytes flow — and what that means for cost and trust.
 

--- a/src/content/use-cases/en/scheduled-cloud-backup.mdx
+++ b/src/content/use-cases/en/scheduled-cloud-backup.mdx
@@ -4,7 +4,7 @@ title: "Scheduled cloud backup — Syncologic"
 description: "Back up important cloud folders to S3 or another destination on a schedule, with change detection and a report at the end of every run."
 eyebrow: "For users and small teams who want recurring backups"
 headline: "Back up cloud folders on a schedule."
-subheading: "Scheduled cloud backups with change detection and a report after every run."
+subheading: "Set a schedule once. Each run only moves what changed since the last one, and you get a report when it's done."
 primaryCta:
   label: "Join the waitlist"
   href: "#waitlist"
@@ -17,9 +17,9 @@ publishedAt: 2026-05-01
 
 ## Who this is for
 
-- Users who treat their Google Drive, OneDrive, or Dropbox as the working copy and want a separate backup somewhere durable.
-- Small teams whose important folders live in a workspace provider but whose disaster-recovery plan is "we hope it stays there".
-- Anyone who has tried to remember to export a folder on the first of every month and given up by month three.
+- You treat your Google Drive, OneDrive, or Dropbox as the working copy and want a separate backup somewhere durable.
+- Your important folders live in a workspace provider, but your disaster-recovery plan is "we hope it stays there."
+- You've tried to remember to export a folder on the first of every month and given up by month three.
 
 ## Cloud storage is not a backup plan
 
@@ -30,37 +30,32 @@ Manual exports work once. They don't survive a busy quarter. The folder you forg
 ## How it'll work
 
 1. Connect the source — Google Drive, OneDrive, Dropbox, Nextcloud, or another provider.
-2. Connect the destination — S3-compatible storage is the common choice, but Drive, Dropbox, and others are supported.
+2. Connect the destination — S3-compatible storage is the common choice; Drive, Dropbox, and others work too.
 3. Pick a schedule — daily, weekly, or continuous.
-4. Pick a runner — Cloud Runner for convenience, Private Runner if the data has to stay in your own infrastructure.
-5. Let the schedule run. Each run only moves what changed since the last one.
+4. Let the schedule run. Each run only moves what changed since the last one.
 
-## Scheduled jobs that actually run
+Where the transfer actually executes — our servers, your browser tab, or a server you own — is a choice you make once. The [homepage walks through the three options](/#how-it-works).
 
-Set a schedule once and the job will run on its own — daily snapshots, weekly workspace copies, a continuous mirror of a critical project. The schedule keeps the backup current; you stop being the cron job.
+## A schedule that actually runs
 
-## Change detection between runs
+Set it once and the job runs on its own — daily snapshots, weekly workspace copies, a continuous mirror of a critical project. The schedule keeps the backup current. You stop being the cron job.
 
-Each run will compare the source against the last successful backup and copy only what's new or changed. The first run moves everything. Every run after that moves a fraction of it — fast, predictable, and cheap to store.
+## Only what changed
+
+Each run compares the source against the last successful backup and copies only what's new or changed. The first run moves everything. Every run after that moves a fraction — fast, predictable, and cheap to store.
 
 ## A report after every run
 
-When a run finishes you'll get a structured report: what copied, what was skipped, what failed. Keep it as the audit trail. If something failed, re-run only the failed items instead of redoing the whole job.
+When a run finishes you get a structured report: what copied, what was skipped, what failed. Keep it as the audit trail. If something failed, re-run only the failed items instead of redoing the whole job.
 
-## Destination options
+## Common pairs
 
 S3-compatible storage is the most common backup destination — durable, cheap at rest, decoupled from your working provider. The same job can also write to a second cloud drive or a Nextcloud / WebDAV target you control.
-
-Common pairs we expect to see:
 
 - Google Drive → S3-compatible storage
 - OneDrive → S3-compatible storage
 - Dropbox → S3-compatible storage
 - Nextcloud → S3-compatible storage
 - Google Drive → Dropbox
-
-## Pricing signal
-
-Backups are about volume, frequency, and retention — not seats. See pricing for the plan ladder.
 
 How often would you want backups to run? Tell us on the waitlist below — it's the first question we'll ask after your email.

--- a/src/content/use-cases/pt-br/private-runner.mdx
+++ b/src/content/use-cases/pt-br/private-runner.mdx
@@ -4,7 +4,7 @@ title: "Private Runner — transferências na sua própria infraestrutura"
 description: "Rode transferências entre nuvens pelo seu próprio servidor, NAS ou VPS. Bytes e credenciais ficam em uma infraestrutura que você controla."
 eyebrow: "Para privacidade, homelabs e empresas com dados sensíveis"
 headline: "Rode transferências no seu próprio servidor, NAS ou VPS."
-subheading: "Camada de controle hospedada, seu caminho de dados. Bytes e credenciais ficam em uma infraestrutura que você controla."
+subheading: "Os arquivos nunca passam pela nossa infraestrutura. A transferência roda em um servidor que você possui, direto entre as nuvens de origem e destino."
 primaryCta:
   label: "Entrar na lista de espera"
   href: "#waitlist"
@@ -17,68 +17,55 @@ publishedAt: 2026-05-01
 
 ## Para quem é isso
 
-- Quem se importa com privacidade e quer uma camada de controle hospedada, mas não uma camada de dados hospedada.
-- Pequenas empresas com dados sensíveis — arquivos jurídicos, registros financeiros, conteúdo regulado — que não devem passar pela infraestrutura de mais ninguém.
-- Operadores de homelab com um servidor, NAS ou VPS sempre ligado, já preparado para esse tipo de job.
-- Usuários de alto volume que preferem pagar pelo software e entrar com a própria banda do que alugar throughput.
-
-## O caminho dos dados
-
-O Cloud Runner envia bytes pela infraestrutura da Syncologic. O Private Runner, não.
-
-`Provedor de origem` → `Seu Private Runner` → `Provedor de destino`
-
-Os arquivos passam direto da API da origem para o runner que você opera, e em seguida para o destino. A camada de controle vê qual é o job e quando rodou — nunca o conteúdo dos arquivos, nunca credenciais de longa duração.
-
-## Conexão apenas de saída
-
-Você não abre porta nenhuma. O runner faz uma conexão de saída para a camada de controle e fica esperando trabalho. Quando um job é despachado, ele puxa um lease de execução de curta duração, roda a transferência e devolve eventos de progresso.
-
-Isso significa:
-
-- Sem regras de firewall de entrada.
-- Sem necessidade de IP público.
-- Sem proxy reverso ou túnel.
-- Funciona atrás de NAT residencial, atrás de proxy corporativo, atrás de qualquer coisa que permita HTTPS de saída.
+- Você não quer infraestrutura de mais ninguém no caminho dos seus arquivos.
+- Você lida com material sensível — arquivos jurídicos, registros financeiros, conteúdo regulado — que não pode passar pelos servidores de outra pessoa.
+- Você já tem um servidor, NAS ou VPS sempre ligado, preparado para esse tipo de job.
+- Você move volume suficiente para que entrar com a própria banda saia mais barato do que alugar throughput.
 
 ## Como vai funcionar
 
 1. Instale o runner em um hardware que você controla — um NAS, uma VPS, um Linux sempre ligado ou um Raspberry Pi que fica ligado.
 2. Pareie com sua conta Syncologic usando um código de inscrição de uso único.
-3. Conecte os provedores de origem e destino pela camada de controle, normalmente.
-4. Quando despachar um job, escolha o Private Runner em vez do Cloud Runner.
+3. Conecte os provedores de origem e destino pelo painel.
+4. Quando começar um job, escolha o runner que você acabou de parear em vez da opção hospedada.
 5. O runner puxa o trabalho, transfere os arquivos entre as APIs dos provedores e devolve um relatório quando terminar.
+
+O diagrama do hero acima mostra o caminho. Os arquivos vão direto da API da origem para o seu runner e em seguida para o destino. A gente vê qual é o job e quando rodou — nunca o conteúdo dos arquivos.
+
+## Sem mexer no firewall
+
+Funciona atrás de NAT residencial, atrás de proxy corporativo, atrás de qualquer coisa que permita HTTPS de saída. Você não abre porta nenhuma. O runner faz uma conexão de saída para a gente e fica esperando trabalho; quando um job é despachado, ele puxa um lease de execução de curta duração, roda a transferência e devolve eventos de progresso.
+
+Sem regras de firewall de entrada. Sem IP público. Sem proxy reverso. Sem túnel.
 
 ## Onde você rodaria
 
-O runner é pequeno o bastante para conviver com outros serviços leves em hardware que você já tem.
+O runner é pequeno o bastante para conviver com outros serviços leves em hardware que você já tem — um Synology, QNAP ou TrueNAS já ligado 24/7, um servidor Linux de homelab ou mini-PC, uma VPS pequena (Hetzner, Fly, DigitalOcean, OVH), uma workstation sempre ligada funcionando como pequeno servidor doméstico, ou um dispositivo da classe Raspberry Pi para backups mais lentos e de baixo throughput.
 
-- Um Synology, QNAP ou TrueNAS que já fica ligado 24/7.
-- Um servidor Linux de homelab ou mini-PC rodando outros jobs de longa duração.
-- Uma VPS pequena — Hetzner, Fly, DigitalOcean, OVH — para quem quer fora das instalações mas ainda na própria conta.
-- Uma workstation sempre ligada funcionando como pequeno servidor doméstico, para migrações pontuais.
-- Um dispositivo da classe Raspberry Pi para backups mais lentos e de baixo throughput.
+Ele se importa com uma rede confiável e disco suficiente para buffers de staging; não se importa com a distro ou o hardware que você escolheu.
 
-O runner se importa com uma rede confiável e disco suficiente para buffers de staging; não se importa com a distro ou o hardware que você escolheu.
+## Suas credenciais ficam com você
 
-## Como as credenciais são tratadas
+Os tokens OAuth dos provedores ficam vinculados ao runner — criptografados em repouso com uma chave derivada da sua inscrição, sem nunca sair do runner. A gente vê identificadores de provedor, escopos e metadados de execução; nunca refresh tokens, nunca conteúdo de arquivos.
 
-Os tokens OAuth dos provedores ficam vinculados ao runner — criptografados em repouso com uma chave derivada da sua inscrição, sem nunca sair do runner. A camada de controle vê identificadores de provedor, escopos e metadados de execução; nunca refresh tokens, nunca conteúdo de arquivos.
+Desative o runner e revogue a inscrição no painel — os tokens que ele guardava ficam inúteis.
 
-Desative o runner e revogue a inscrição na camada de controle — os tokens que ele guardava ficam inúteis.
+## Hospedado versus seu próprio servidor
 
-## Cloud Runner vs Private Runner
+<PricingCurves />
 
-### Cloud Runner
+Os dois modos usam o mesmo painel, as mesmas definições de job, a mesma prévia e os mesmos relatórios de conclusão. A única diferença é por onde os bytes passam — e o que isso significa para custo e confiança.
 
-- **Por onde os bytes passam:** origem → infraestrutura da Syncologic → destino.
+### Nos nossos servidores (Cloud Runner)
+
+- **Por onde os bytes passam:** origem → nossa infraestrutura → destino.
 - **Onde ficam as credenciais:** criptografadas na nossa infraestrutura, de curta duração.
 - **Esforço de setup:** nenhum — escolha no dropdown.
 - **Quando faz mais sentido:** praticidade, jobs muito grandes que você não quer hospedar.
 - **Modelo de preço:** baseado em uso na nossa infraestrutura.
 - **Requisitos de rede:** nenhum.
 
-### Private Runner
+### No seu próprio servidor (Private Runner)
 
 - **Por onde os bytes passam:** origem → seu servidor → destino.
 - **Onde ficam as credenciais:** no seu runner, sem nunca sair de lá.
@@ -87,10 +74,8 @@ Desative o runner e revogue a inscrição na camada de controle — os tokens qu
 - **Modelo de preço:** você paga pelo software e entra com a banda.
 - **Requisitos de rede:** HTTPS de saída a partir do runner.
 
-Os dois runners usam a mesma camada de controle, as mesmas definições de job, a mesma prévia e os mesmos relatórios de conclusão. A única diferença é por onde os bytes passam.
+## Código público
 
-## Código visível e um caminho futuro de auto-hospedagem
-
-O runner vai funcionar com a nossa camada de controle hospedada no lançamento e, mais tarde, com uma camada de controle auto-hospedada. O código principal vai ser lançado com código visível — você pode auditar antes de instalar. A auto-hospedagem da camada de controle é uma trilha separada e mais longa; o Private Runner é o primeiro passo.
+Você pode auditar como o runner move os arquivos antes de instalar — o código é público. A gente pretende manter essa propriedade enquanto cresce.
 
 Onde você rodaria seu Private Runner — NAS, servidor de homelab, VPS ou workstation? Conte para a gente na lista de espera abaixo — é a primeira pergunta que vamos fazer depois do seu e-mail.

--- a/src/content/use-cases/pt-br/private-runner.mdx
+++ b/src/content/use-cases/pt-br/private-runner.mdx
@@ -52,7 +52,7 @@ Desative o runner e revogue a inscrição no painel — os tokens que ele guarda
 
 ## Hospedado versus seu próprio servidor
 
-<PricingCurves />
+<HostedVsPrivatePath />
 
 Os dois modos usam o mesmo painel, as mesmas definições de job, a mesma prévia e os mesmos relatórios de conclusão. A única diferença é por onde os bytes passam — e o que isso significa para custo e confiança.
 

--- a/src/content/use-cases/pt-br/scheduled-cloud-backup.mdx
+++ b/src/content/use-cases/pt-br/scheduled-cloud-backup.mdx
@@ -4,7 +4,7 @@ title: "Backup agendado para a nuvem — Syncologic"
 description: "Faça backup de pastas importantes da nuvem para S3 ou outro destino em um agendamento, com detecção de alterações e um relatório no final de cada run."
 eyebrow: "Para usuários e times pequenos que querem backups recorrentes"
 headline: "Faça backup de pastas da nuvem em um agendamento."
-subheading: "Backups agendados na nuvem com detecção de alterações e um relatório depois de cada run."
+subheading: "Defina um agendamento uma vez. Cada run só move o que mudou desde a última, e você recebe um relatório quando termina."
 primaryCta:
   label: "Entrar na lista de espera"
   href: "#waitlist"
@@ -17,9 +17,9 @@ publishedAt: 2026-05-01
 
 ## Para quem é isso
 
-- Quem trata o Google Drive, o OneDrive ou o Dropbox como cópia de trabalho e quer um backup separado em algum lugar durável.
-- Times pequenos cujas pastas importantes ficam em um provedor de workspace mas cujo plano de recuperação de desastre é "torcer para continuar lá".
-- Qualquer pessoa que já tentou lembrar de exportar uma pasta no primeiro dia do mês e desistiu no terceiro mês.
+- Você trata o Google Drive, o OneDrive ou o Dropbox como cópia de trabalho e quer um backup separado em algum lugar durável.
+- Suas pastas importantes ficam em um provedor de workspace, mas o seu plano de recuperação de desastre é "torcer para continuar lá".
+- Você já tentou lembrar de exportar uma pasta no primeiro dia do mês e desistiu no terceiro mês.
 
 ## Armazenamento na nuvem não é plano de backup
 
@@ -30,37 +30,32 @@ Exportações manuais funcionam uma vez. Não sobrevivem a um trimestre cheio. A
 ## Como vai funcionar
 
 1. Conecte a origem — Google Drive, OneDrive, Dropbox, Nextcloud ou outro provedor.
-2. Conecte o destino — armazenamento compatível com S3 é a escolha mais comum, mas Drive, Dropbox e outros também são suportados.
+2. Conecte o destino — armazenamento compatível com S3 é a escolha mais comum; Drive, Dropbox e outros também funcionam.
 3. Escolha um agendamento — diário, semanal ou contínuo.
-4. Escolha um runner — Cloud Runner para praticidade, Private Runner se os dados precisam ficar na sua própria infraestrutura.
-5. Deixe a programação rodar. Cada run só move o que mudou desde a última.
+4. Deixe a programação rodar. Cada run só move o que mudou desde a última.
 
-## Jobs agendados que de fato rodam
+Onde a transferência de fato roda — nos nossos servidores, na sua aba de navegador ou em um servidor que você possui — é uma escolha que você faz uma vez. A [home explica as três opções](/pt-br/#how-it-works).
 
-Defina um agendamento uma vez e o job vai rodar sozinho — snapshots diários, cópias semanais de workspace, um mirror contínuo de um projeto crítico. O agendamento mantém o backup em dia; você deixa de ser o cron job.
+## Um agendamento que de fato roda
 
-## Detecção de alterações entre runs
+Defina uma vez e o job vai rodar sozinho — snapshots diários, cópias semanais de workspace, um mirror contínuo de um projeto crítico. O agendamento mantém o backup em dia. Você deixa de ser o cron job.
 
-Cada run vai comparar a origem com o último backup bem-sucedido e copiar só o que é novo ou mudou. O primeiro run move tudo. Cada run seguinte move uma fração — rápido, previsível e barato de guardar.
+## Só o que mudou
+
+Cada run compara a origem com o último backup bem-sucedido e copia só o que é novo ou mudou. O primeiro run move tudo. Cada run seguinte move uma fração — rápido, previsível e barato de guardar.
 
 ## Um relatório depois de cada run
 
 Quando um run terminar, você recebe um relatório estruturado: o que foi copiado, o que foi ignorado, o que falhou. Guarde como trilha de auditoria. Se algo falhar, rode de novo só os itens que falharam em vez de refazer o job inteiro.
 
-## Opções de destino
+## Pares comuns
 
 Armazenamento compatível com S3 é o destino de backup mais comum — durável, barato em repouso e desacoplado do seu provedor de trabalho. O mesmo job também pode escrever em um segundo drive na nuvem ou em um destino Nextcloud / WebDAV que você controla.
-
-Pares comuns que esperamos ver:
 
 - Google Drive → armazenamento compatível com S3
 - OneDrive → armazenamento compatível com S3
 - Dropbox → armazenamento compatível com S3
 - Nextcloud → armazenamento compatível com S3
 - Google Drive → Dropbox
-
-## Sinal de preço
-
-Backups são sobre volume, frequência e retenção — não sobre licenças por usuário. Veja preços para a estrutura de planos.
 
 Com que frequência você gostaria que os backups rodassem? Conte para a gente na lista de espera abaixo — é a primeira pergunta que vamos fazer depois do seu e-mail.

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -239,6 +239,11 @@
     },
     "beforeAfterTransfer": {
       "alt": "Two stacked panels. The top panel shows the manual approach: files travel from one cloud, through a laptop in the middle, on to the second cloud — and every so often break at the laptop, turning red. The bottom panel shows the direct approach: a single brand-blue arc carries files from the first cloud straight to the second, bypassing the laptop entirely."
+    },
+    "hostedVsPrivatePath": {
+      "alt": "Two stacked architecture diagrams, one above the other. Each one shows files moving between two clouds through a middle box. On the top diagram, the middle box is labelled 'Our servers'. On the bottom diagram, the middle box is labelled 'Your server'. The two paths are otherwise identical — same arc, same file pills — to make the only difference the location of the middle box.",
+      "hostedLabel": "Our servers",
+      "privateLabel": "Your server"
     }
   },
   "guides": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -239,6 +239,11 @@
     },
     "beforeAfterTransfer": {
       "alt": "Dois painéis empilhados. No painel de cima, o caminho manual: os arquivos saem de uma nuvem, passam por um notebook no meio e seguem para a segunda nuvem — e de vez em quando quebram no notebook, ficando vermelhos. No painel de baixo, o caminho direto: um único arco azul leva os arquivos da primeira nuvem direto para a segunda, sem passar pelo notebook."
+    },
+    "hostedVsPrivatePath": {
+      "alt": "Dois diagramas de arquitetura empilhados, um acima do outro. Cada um mostra arquivos passando entre duas nuvens por uma caixa do meio. No diagrama de cima, a caixa do meio está rotulada 'Nossos servidores'. No de baixo, a caixa do meio está rotulada 'Seu servidor'. Os dois caminhos são idênticos no resto — mesmo arco, mesmas fichas de arquivo — para que a única diferença seja a localização da caixa do meio.",
+      "hostedLabel": "Nossos servidores",
+      "privateLabel": "Seu servidor"
     }
   },
   "guides": {

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -11,6 +11,7 @@ import PrivateRunnerPath from '../../../components/visuals/PrivateRunnerPath.ast
 import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
 import BeforeAfterTransfer from '../../../components/visuals/BeforeAfterTransfer.astro';
 import PricingCurves from '../../../components/visuals/PricingCurves.astro';
+import HostedVsPrivatePath from '../../../components/visuals/HostedVsPrivatePath.astro';
 import GuideCrossLinks from '../../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
@@ -59,7 +60,7 @@ const crossLinks = crossLinkMap[slug] ?? [];
     )}
   </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content components={{ BeforeAfterTransfer, PricingCurves, ScheduleClock }} />
+    <Content components={{ BeforeAfterTransfer, PricingCurves, ScheduleClock, HostedVsPrivatePath }} />
   </article>
   {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -10,6 +10,7 @@ import MigrationChecklist from '../../../components/visuals/MigrationChecklist.a
 import PrivateRunnerPath from '../../../components/visuals/PrivateRunnerPath.astro';
 import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
 import BeforeAfterTransfer from '../../../components/visuals/BeforeAfterTransfer.astro';
+import PricingCurves from '../../../components/visuals/PricingCurves.astro';
 import GuideCrossLinks from '../../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
@@ -58,7 +59,7 @@ const crossLinks = crossLinkMap[slug] ?? [];
     )}
   </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content components={{ BeforeAfterTransfer }} />
+    <Content components={{ BeforeAfterTransfer, PricingCurves, ScheduleClock }} />
   </article>
   {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -10,6 +10,7 @@ import MigrationChecklist from '../../components/visuals/MigrationChecklist.astr
 import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
 import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
 import BeforeAfterTransfer from '../../components/visuals/BeforeAfterTransfer.astro';
+import PricingCurves from '../../components/visuals/PricingCurves.astro';
 import GuideCrossLinks from '../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
@@ -58,7 +59,7 @@ const crossLinks = crossLinkMap[slug] ?? [];
     )}
   </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content components={{ BeforeAfterTransfer }} />
+    <Content components={{ BeforeAfterTransfer, PricingCurves, ScheduleClock }} />
   </article>
   {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -11,6 +11,7 @@ import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro'
 import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
 import BeforeAfterTransfer from '../../components/visuals/BeforeAfterTransfer.astro';
 import PricingCurves from '../../components/visuals/PricingCurves.astro';
+import HostedVsPrivatePath from '../../components/visuals/HostedVsPrivatePath.astro';
 import GuideCrossLinks from '../../components/sections/GuideCrossLinks.astro';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
@@ -59,7 +60,7 @@ const crossLinks = crossLinkMap[slug] ?? [];
     )}
   </Hero>
   <article class="prose-syncologic container-wide max-w-[760px] py-section">
-    <Content components={{ BeforeAfterTransfer, PricingCurves, ScheduleClock }} />
+    <Content components={{ BeforeAfterTransfer, PricingCurves, ScheduleClock, HostedVsPrivatePath }} />
   </article>
   {crossLinks.length > 0 && <GuideCrossLinks slugs={crossLinks} />}
   <WaitlistForm segmentHint={entry.data.waitlistSegment} />


### PR DESCRIPTION
## Summary
- Rewrote `/use-cases/private-runner` (en + pt-BR) with a plain-language hero subheading (no more "Hosted control plane" leading the page), dropped the "Three ways to run a transfer at launch"-shaped data-path prose duplicating the hero diagram, and paired the Cloud-vs-Private comparison with `<PricingCurves />` so the cost crossover argument has a picture instead of running as bullet text only.
- Rewrote `/use-cases/scheduled-cloud-backup` (en + pt-BR): dropped the runner roll-call from "How it'll work" step 4 in favor of a single sentence linking the homepage `/#how-it-works` section, removed the standalone "Pricing signal" one-liner, and tightened each remaining section to ≤ 2 short paragraphs.
- Exposed `PricingCurves` and `ScheduleClock` to the use-case MDX `components` map in `src/pages/{,pt-br/}use-cases/[slug].astro` so future use-case pages can also reference them inline.

## Closes
Closes #152

## Test plan
- [x] `npx astro check` — 0 errors, 0 warnings (2 pre-existing hints unrelated to this PR).
- [x] `npm run build` — clean; all four use-case routes prerender (en + pt-BR × private-runner + scheduled-cloud-backup).
- [x] HTML render check on the built dist — `pricing-curves` markup present once on each private-runner page and absent from scheduled-cloud-backup pages; rewritten section headings (e.g. "Hosted versus your own server", "Hospedado versus seu próprio servidor", "Sem mexer no firewall") all render.
- [x] `grep -nE 'Cloud Runner\|Browser Runner\|Private Runner\|control plane\|data plane'` on the four MDX files — only valid hits remain (page title, parenthetical alias after plain-language description, closing CTA).
- [x] `grep -nEi 'your machine\|sua máquina\|na máquina'` on the four MDX files — zero hits.

## Visual verification (UI changes only)
Verified by HTML inspection on the built dist for `/use-cases/private-runner`, `/pt-br/use-cases/private-runner`, `/use-cases/scheduled-cloud-backup`, and `/pt-br/use-cases/scheduled-cloud-backup`. Cross-breakpoint browser verification (375 / 768 / 1024 / 1440) and `prefers-reduced-motion` regression check on the reused `PricingCurves` are pending — recommend a quick spot-check before merge.

## Notes
- No dependency changes. No new visual files, no new i18n keys; both reused visuals (`PricingCurves`, `ScheduleClock`) self-localize via existing `visuals.*.alt` strings.
- Issue #152 listed an optional inline reuse of `<ScheduleClock />` next to the "Only what changed" body section. I deliberately skipped it — duplicating the hero visual within the same page (the hero visual is `ScheduleClock` already) read as awkward repetition rather than reinforcement, and the body section is short enough to stand text-only as the kind of justified exception that `voice-and-rules.md` allows. The hero carries the page's visual weight; `PricingCurves` on the private-runner page is the only inline body visual added in this PR.
- The `[homepage walks through the three options](/#how-it-works)` link uses the existing `id="how-it-works"` on the homepage runners section (`src/pages/index.astro:89`).
