### PR TITLE
Developers page: dedicated #oauth section + new visual + label fix

### DIFF
--- a/src/components/sections/DevelopersPage.astro
+++ b/src/components/sections/DevelopersPage.astro
@@ -5,6 +5,7 @@ import Hero from './Hero.astro';
 import FAQ from './FAQ.astro';
 import WaitlistForm from './WaitlistForm.astro';
 import DeveloperTerminal from '../visuals/DeveloperTerminal.astro';
+import OAuthIntermediary from '../visuals/OAuthIntermediary.astro';
 import { getLocaleFromUrl } from '../../i18n/utils';
 import en from '../../i18n/en.json';
 import ptBr from '../../i18n/pt-br.json';
@@ -62,7 +63,18 @@ const runners = [dev.runnerCloud, dev.runnerBrowser, dev.runnerPrivate];
   </div>
 </Section>
 
-<Section surface="white" padding="lg" id="cli">
+<Section surface="white" padding="lg" id="oauth">
+  <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,520px)] gap-12 items-center">
+    <div class="flex flex-col gap-3">
+      <h2 class="text-h1 font-medium text-dark-charcoal">{dev.oauthTitle}</h2>
+      <p class="text-body text-slate-gray">{dev.oauthBody}</p>
+      <p class="text-caption text-slate-gray">{dev.oauthCaption}</p>
+    </div>
+    <OAuthIntermediary />
+  </div>
+</Section>
+
+<Section surface="soft" padding="lg" id="cli">
   <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,760px)] gap-12 items-start">
     <div class="flex flex-col gap-3">
       <h2 class="text-h1 font-medium text-dark-charcoal">{dev.cliTitle}</h2>
@@ -75,7 +87,7 @@ const runners = [dev.runnerCloud, dev.runnerBrowser, dev.runnerPrivate];
   </div>
 </Section>
 
-<Section surface="soft" padding="lg" id="runners">
+<Section surface="white" padding="lg" id="runners">
   <div class="text-center mb-12 max-w-2xl mx-auto">
     <h2 class="text-h1 font-medium text-dark-charcoal mb-3">{dev.runnersTitle}</h2>
     <p class="text-body text-slate-gray">{dev.runnersBody}</p>
@@ -88,9 +100,15 @@ const runners = [dev.runnerCloud, dev.runnerBrowser, dev.runnerPrivate];
       </Card>
     ))}
   </div>
+  <p class="text-caption text-slate-gray text-center mt-10">
+    {dev.runnersFooterText}{' '}
+    <a href={locale === 'pt-br' ? '/pt-br/self-hosted' : '/self-hosted'} class="text-brand-blue hover:underline focus-visible:underline">
+      {dev.runnersFooterLink} →
+    </a>
+  </p>
 </Section>
 
-<Section surface="white" padding="lg" id="webhooks">
+<Section surface="soft" padding="lg" id="webhooks">
   <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,420px)_minmax(0,1fr)] gap-10 items-start">
     <div class="flex flex-col gap-3">
       <h2 class="text-h1 font-medium text-dark-charcoal">{dev.webhooksTitle}</h2>

--- a/src/components/visuals/OAuthIntermediary.astro
+++ b/src/components/visuals/OAuthIntermediary.astro
@@ -1,0 +1,144 @@
+---
+import { getLocaleFromUrl, getT } from '../../i18n/utils';
+
+const locale = getLocaleFromUrl(Astro.url);
+const t = getT(locale);
+const altLabel = t('visuals.oauthIntermediary.alt');
+const appLabel = t('visuals.oauthIntermediary.appLabel');
+const syncologicLabel = t('visuals.oauthIntermediary.syncologicLabel');
+const providerLabel = t('visuals.oauthIntermediary.providerLabel');
+const apiArrowLabel = t('visuals.oauthIntermediary.apiArrowLabel');
+const oauthArrowLabel = t('visuals.oauthIntermediary.oauthArrowLabel');
+const noTokenLabel = t('visuals.oauthIntermediary.noTokenLabel');
+---
+
+<div class="oauth-intermediary w-full max-w-[480px] mx-auto" role="presentation">
+  <svg
+    viewBox="0 0 480 280"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label={altLabel}
+    class="w-full h-auto block"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <g aria-hidden="true">
+      <rect x="20" y="80" width="110" height="80" rx="14" class="fill-white stroke-slate-gray" stroke-width="1.2" />
+      <g transform="translate(75 110)" class="stroke-slate-gray" stroke-width="1.5" fill="none">
+        <polyline points="-9,-6 -16,0 -9,6" />
+        <polyline points="9,-6 16,0 9,6" />
+        <line x1="-3" y1="-7" x2="3" y2="7" />
+      </g>
+      <text x="75" y="148" class="box-label fill-dark-charcoal" text-anchor="middle">{appLabel}</text>
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="185" y="80" width="110" height="80" rx="14" class="fill-baby-blue stroke-brand-blue" stroke-width="1.5" />
+      <g transform="translate(240 110)" class="stroke-brand-blue" stroke-width="1.5" fill="none">
+        <rect x="-14" y="-9" width="28" height="18" rx="4" />
+        <line x1="-14" y1="-3" x2="14" y2="-3" />
+        <line x1="-9" y1="3" x2="9" y2="3" />
+      </g>
+      <text x="240" y="148" class="box-label fill-dark-charcoal" text-anchor="middle">{syncologicLabel}</text>
+    </g>
+
+    <g aria-hidden="true">
+      <rect x="350" y="80" width="110" height="80" rx="14" class="fill-soft-gray stroke-slate-gray" stroke-width="1.2" />
+      <g transform="translate(405 110)" class="stroke-slate-gray fill-white" stroke-width="1.5">
+        <path d="M -16 6 C -22 6, -22 -2, -16 -2 C -16 -10, 0 -12, 2 -4 C 12 -4, 12 6, 4 6 Z" />
+      </g>
+      <text x="405" y="148" class="box-label fill-dark-charcoal" text-anchor="middle">{providerLabel}</text>
+    </g>
+
+    <g class="api-arrow stroke-brand-blue" stroke-width="1.5" fill="none">
+      <line x1="135" y1="115" x2="180" y2="115" />
+      <polyline points="172,110 180,115 172,120" class="fill-none" />
+      <line x1="180" y1="125" x2="135" y2="125" />
+      <polyline points="143,120 135,125 143,130" class="fill-none" />
+    </g>
+    <text x="157" y="100" class="arrow-label fill-slate-gray" text-anchor="middle" aria-hidden="true">{apiArrowLabel}</text>
+
+    <g class="oauth-arrow stroke-brand-blue" stroke-width="1.5" fill="none">
+      <line x1="300" y1="115" x2="345" y2="115" />
+      <polyline points="337,110 345,115 337,120" class="fill-none" />
+      <line x1="345" y1="125" x2="300" y2="125" />
+      <polyline points="308,120 300,125 308,130" class="fill-none" />
+    </g>
+    <text x="322" y="100" class="arrow-label fill-slate-gray" text-anchor="middle" aria-hidden="true">{oauthArrowLabel}</text>
+
+    <g class="no-token" aria-hidden="true">
+      <line x1="135" y1="220" x2="345" y2="220" stroke-width="1" stroke-dasharray="3 5" class="stroke-divider" />
+      <g transform="translate(240 220)" class="stroke-error" stroke-width="1.5" fill="none">
+        <circle r="9" class="fill-white" />
+        <line x1="-4" y1="-4" x2="4" y2="4" />
+        <line x1="4" y1="-4" x2="-4" y2="4" />
+      </g>
+      <text x="240" y="248" class="no-token-label fill-slate-gray" text-anchor="middle">{noTokenLabel}</text>
+    </g>
+
+    <g class="api-pulse" aria-hidden="true">
+      <circle r="3" class="fill-brand-blue" />
+    </g>
+    <g class="oauth-pulse" aria-hidden="true">
+      <circle r="3" class="fill-brand-blue" />
+    </g>
+  </svg>
+</div>
+
+<style>
+  .oauth-intermediary { min-width: 280px; }
+
+  .box-label {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .arrow-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+  .no-token-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+
+  .api-pulse,
+  .oauth-pulse {
+    transform-box: fill-box;
+    transform-origin: center;
+    opacity: 0;
+  }
+  .api-pulse {
+    offset-path: path('M 135 120 L 180 120');
+    offset-distance: 0%;
+    offset-rotate: 0deg;
+  }
+  .oauth-pulse {
+    offset-path: path('M 300 120 L 345 120');
+    offset-distance: 0%;
+    offset-rotate: 0deg;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .api-pulse   { animation: oi-pulse 3.5s ease-in-out infinite; }
+    .oauth-pulse { animation: oi-pulse 3.5s ease-in-out infinite 1.75s; }
+
+    @keyframes oi-pulse {
+      0%   { offset-distance: 0%;   opacity: 0; }
+      8%   { offset-distance: 4%;   opacity: 1; }
+      45%  { offset-distance: 96%;  opacity: 1; }
+      53%  { offset-distance: 100%; opacity: 0; }
+      55%  { offset-distance: 100%; opacity: 0; }
+      63%  { offset-distance: 96%;  opacity: 1; }
+      92%  { offset-distance: 4%;   opacity: 1; }
+      100% { offset-distance: 0%;   opacity: 0; }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .api-pulse,
+    .oauth-pulse { display: none; }
+  }
+</style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -475,7 +475,7 @@
     },
     "runnerPrivate": {
       "title": "Private Runner",
-      "desc": "Self-host the runner binary in your VPC, on-prem, or on a NAS. Outbound-only connection to the control plane."
+      "desc": "Self-host the runner binary on a VPS, on-prem server, or NAS. Outbound-only connection to the control plane."
     },
     "webhooksTitle": "Webhooks for the events you care about",
     "webhooksBody": "Subscribe to job lifecycle events and stream them into your queue, your dashboard, or your audit log. Payloads will be HMAC-signed.",
@@ -508,7 +508,7 @@
       },
       {
         "q": "Can I run jobs entirely on my own infrastructure?",
-        "a": "Yes for the data path — Private Runner runs in your VPC, NAS, or any server you control, and file bytes never reach Syncologic.",
+        "a": "Yes for the data path — Private Runner runs on any server you control, and file bytes never reach Syncologic.",
         "link": { "href": "/self-hosted", "label": "Architecture and roadmap" }
       },
       {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -241,9 +241,18 @@
       "alt": "Two stacked panels. The top panel shows the manual approach: files travel from one cloud, through a laptop in the middle, on to the second cloud — and every so often break at the laptop, turning red. The bottom panel shows the direct approach: a single brand-blue arc carries files from the first cloud straight to the second, bypassing the laptop entirely."
     },
     "hostedVsPrivatePath": {
-      "alt": "Two stacked architecture diagrams, one above the other. Each one shows files moving between two clouds through a middle box. On the top diagram, the middle box is labelled 'Our servers'. On the bottom diagram, the middle box is labelled 'Your server'. The two paths are otherwise identical — same arc, same file pills — to make the only difference the location of the middle box.",
-      "hostedLabel": "Our servers",
+      "alt": "Two stacked architecture diagrams, one above the other. Each one shows files moving between two clouds through a middle box. On the top diagram, the middle box is labelled 'Our server'. On the bottom diagram, the middle box is labelled 'Your server'. The two paths are otherwise identical — same arc, same file pills — to make the only difference the location of the middle box.",
+      "hostedLabel": "Our server",
       "privateLabel": "Your server"
+    },
+    "oauthIntermediary": {
+      "alt": "Three boxes left to right — your app, Syncologic, and the cloud provider. A bidirectional arrow labelled 'API' connects your app to Syncologic. A second bidirectional arrow labelled 'OAuth' connects Syncologic to the provider. There is no direct line from your app to the provider; a struck-out dashed line below the boxes makes the absence explicit, with the caption 'no provider token reaches your app.'",
+      "appLabel": "Your app",
+      "syncologicLabel": "Syncologic",
+      "providerLabel": "Provider",
+      "apiArrowLabel": "API",
+      "oauthArrowLabel": "OAuth",
+      "noTokenLabel": "no provider token reaches your app"
     }
   },
   "guides": {
@@ -446,11 +455,16 @@
     "apiTitle": "A typed HTTP API",
     "apiBody": "Create a job with a source, destination, runner, and optional schedule. The control plane validates, dispatches, and emits progress events.",
     "apiCaption": "Sketch — final shape will land with the v1 API.",
+    "oauthTitle": "OAuth lives on our side",
+    "oauthBody": "Your users connect their cloud accounts to Syncologic, not to your app. You never store provider credentials. The control plane manages the OAuth lifecycle and hands out scoped, short-lived tokens to runners — your app authenticates with Syncologic via your API key and never sees a provider token.",
+    "oauthCaption": "Your app integrates the API; the OAuth boundary stays on our side.",
     "cliTitle": "A CLI for scripts and CI",
     "cliBody": "Same jobs, driven from a terminal or a CI runner. Useful for one-shot migrations and for backups owned by a script you can read in a code review.",
     "cliCaption": "Planned. Behavior mirrors the API one-to-one.",
     "runnersTitle": "Pick the runner that fits the job",
     "runnersBody": "Same API. Three different data paths. Choose per job, not per account.",
+    "runnersFooterText": "Want the full Private Runner walkthrough?",
+    "runnersFooterLink": "See /self-hosted",
     "runnerCloud": {
       "title": "Cloud Runner",
       "desc": "Hosted runners for scheduled jobs and large migrations. No infrastructure on your side."
@@ -489,11 +503,13 @@
       },
       {
         "q": "Do you handle OAuth on behalf of my users?",
-        "a": "Yes. Users connect their cloud accounts to Syncologic — not to your app. You don't store provider credentials; the control plane manages the OAuth lifecycle."
+        "a": "Yes — your app never holds a provider token.",
+        "link": { "href": "#oauth", "label": "How OAuth works" }
       },
       {
         "q": "Can I run jobs entirely on my own infrastructure?",
-        "a": "Yes for the data path — Private Runner runs in your VPC, NAS, or any server you control, and file bytes never reach Syncologic. The control plane (accounts, jobs, schedules) is hosted by us at launch; full self-host is on the roadmap."
+        "a": "Yes for the data path — Private Runner runs in your VPC, NAS, or any server you control, and file bytes never reach Syncologic.",
+        "link": { "href": "/self-hosted", "label": "Architecture and roadmap" }
       },
       {
         "q": "Are webhook payloads signed?",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -475,7 +475,7 @@
     },
     "runnerPrivate": {
       "title": "Private Runner",
-      "desc": "Hospede o binário do runner na sua VPC, on-prem ou em um NAS. Conexão apenas de saída com a camada de controle."
+      "desc": "Hospede o binário do runner em uma VPS, servidor on-prem ou NAS. Conexão apenas de saída com a camada de controle."
     },
     "webhooksTitle": "Webhooks para os eventos que importam",
     "webhooksBody": "Assine os eventos do ciclo de vida dos jobs e direcione para sua fila, seu dashboard ou seu log de auditoria. Os payloads serão assinados com HMAC.",
@@ -508,7 +508,7 @@
       },
       {
         "q": "Posso rodar os jobs inteiramente na minha infraestrutura?",
-        "a": "Sim, no caminho dos dados — o Private Runner roda na sua VPC, num NAS ou em qualquer servidor que você controla, e os bytes dos arquivos nunca chegam à Syncologic.",
+        "a": "Sim, no caminho dos dados — o Private Runner roda em qualquer servidor que você controla, e os bytes dos arquivos nunca chegam à Syncologic.",
         "link": { "href": "/pt-br/self-hosted", "label": "Arquitetura e roadmap" }
       },
       {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -241,9 +241,18 @@
       "alt": "Dois painéis empilhados. No painel de cima, o caminho manual: os arquivos saem de uma nuvem, passam por um notebook no meio e seguem para a segunda nuvem — e de vez em quando quebram no notebook, ficando vermelhos. No painel de baixo, o caminho direto: um único arco azul leva os arquivos da primeira nuvem direto para a segunda, sem passar pelo notebook."
     },
     "hostedVsPrivatePath": {
-      "alt": "Dois diagramas de arquitetura empilhados, um acima do outro. Cada um mostra arquivos passando entre duas nuvens por uma caixa do meio. No diagrama de cima, a caixa do meio está rotulada 'Nossos servidores'. No de baixo, a caixa do meio está rotulada 'Seu servidor'. Os dois caminhos são idênticos no resto — mesmo arco, mesmas fichas de arquivo — para que a única diferença seja a localização da caixa do meio.",
-      "hostedLabel": "Nossos servidores",
+      "alt": "Dois diagramas de arquitetura empilhados, um acima do outro. Cada um mostra arquivos passando entre duas nuvens por uma caixa do meio. No diagrama de cima, a caixa do meio está rotulada 'Nosso servidor'. No de baixo, a caixa do meio está rotulada 'Seu servidor'. Os dois caminhos são idênticos no resto — mesmo arco, mesmas fichas de arquivo — para que a única diferença seja a localização da caixa do meio.",
+      "hostedLabel": "Nosso servidor",
       "privateLabel": "Seu servidor"
+    },
+    "oauthIntermediary": {
+      "alt": "Três caixas da esquerda para a direita — seu app, Syncologic e o provedor de nuvem. Uma seta bidirecional rotulada 'API' liga seu app à Syncologic. Uma segunda seta bidirecional rotulada 'OAuth' liga a Syncologic ao provedor. Não existe nenhuma linha direta entre seu app e o provedor; uma linha pontilhada riscada abaixo das caixas torna a ausência explícita, com a legenda 'nenhum token do provedor chega ao seu app.'",
+      "appLabel": "Seu app",
+      "syncologicLabel": "Syncologic",
+      "providerLabel": "Provedor",
+      "apiArrowLabel": "API",
+      "oauthArrowLabel": "OAuth",
+      "noTokenLabel": "nenhum token do provedor chega ao seu app"
     }
   },
   "guides": {
@@ -446,11 +455,16 @@
     "apiTitle": "Uma API HTTP tipada",
     "apiBody": "Crie um job com origem, destino, runner e um agendamento opcional. A camada de controle valida, despacha e emite eventos de progresso.",
     "apiCaption": "Esboço — o formato final vem com a API v1.",
+    "oauthTitle": "OAuth fica do nosso lado",
+    "oauthBody": "Seus usuários conectam as contas de nuvem deles à Syncologic, não ao seu app. Você nunca guarda credenciais de provedor. A camada de controle cuida do ciclo de vida do OAuth e entrega tokens com escopo e curta duração para os runners — seu app se autentica na Syncologic com a sua chave de API e nunca vê um token de provedor.",
+    "oauthCaption": "Seu app integra a API; a fronteira do OAuth fica do nosso lado.",
     "cliTitle": "Uma CLI para scripts e CI",
     "cliBody": "Os mesmos jobs, executados de um terminal ou de um runner de CI. Útil para migrações pontuais e para backups definidos por um script que você consegue revisar em um code review.",
     "cliCaption": "Planejado. O comportamento espelha a API um-para-um.",
     "runnersTitle": "Escolha o runner que combina com o job",
     "runnersBody": "A mesma API. Três caminhos de dados diferentes. Escolha por job, não por conta.",
+    "runnersFooterText": "Quer o passo a passo completo do Private Runner?",
+    "runnersFooterLink": "Veja /self-hosted",
     "runnerCloud": {
       "title": "Cloud Runner",
       "desc": "Runners hospedados para jobs agendados e grandes migrações. Sem infraestrutura do seu lado."
@@ -489,11 +503,13 @@
       },
       {
         "q": "Vocês cuidam do OAuth em nome dos meus usuários?",
-        "a": "Sim. Os usuários conectam as contas de nuvem deles à Syncologic — não ao seu app. Você não guarda credenciais de provedor; a camada de controle cuida do ciclo de vida do OAuth."
+        "a": "Sim — seu app nunca guarda um token de provedor.",
+        "link": { "href": "#oauth", "label": "Como o OAuth funciona" }
       },
       {
         "q": "Posso rodar os jobs inteiramente na minha infraestrutura?",
-        "a": "Sim, no caminho dos dados — o Private Runner roda na sua VPC, num NAS ou em qualquer servidor que você controla, e os bytes dos arquivos nunca chegam à Syncologic. A camada de controle (contas, jobs, agendamentos) é hospedada por nós no lançamento; auto-hospedagem completa está no roadmap."
+        "a": "Sim, no caminho dos dados — o Private Runner roda na sua VPC, num NAS ou em qualquer servidor que você controla, e os bytes dos arquivos nunca chegam à Syncologic.",
+        "link": { "href": "/pt-br/self-hosted", "label": "Arquitetura e roadmap" }
       },
       {
         "q": "Os payloads dos webhooks são assinados?",


### PR DESCRIPTION
## Summary
- Promoted the OAuth-intermediary trust claim from FAQ Q3 into a dedicated `#oauth` section between `#api` and `#cli`, paired with a new `OAuthIntermediary.astro` visual: three boxes (Your app · Syncologic · Provider) with bidirectional API + OAuth arrows and a struck-out dashed line below making the absence of a direct your-app→provider credential channel explicit.
- Updated FAQ Q3 (OAuth) to a one-line answer that links the new `#oauth` section, and FAQ Q4 (own-infrastructure) to a one-line answer that links `/self-hosted` for the full architecture / roadmap. Added a footer cross-link below the runner cards pointing to `/self-hosted` for the deeper Private Runner walkthrough.
- Tagalong fix: shortened `HostedVsPrivatePath` labels to a singular parallel form (en "Our server"/"Your server", pt-BR "Nosso servidor"/"Seu servidor") so the pt-BR label no longer overflows the middle box on `/use-cases/private-runner`.

## Closes
Closes #154

## Test plan
- [x] `npx astro check` — 0 errors, 0 warnings (2 pre-existing hints unrelated to this PR).
- [x] `npm run build` — clean; both `/developers` routes (en + pt-BR) prerender; both `/use-cases/private-runner` routes still render with the corrected labels.
- [x] HTML render check on the built dist — `oauth-intermediary` markup present once on each `/developers` page (with both the inline visual + the `<details>` summary chevron context); new `#oauth` section heading renders in both locales ("OAuth lives on our side" / "OAuth fica do nosso lado"); `/self-hosted` cross-link renders below the runner cards in both locales.
- [x] HostedVsPrivatePath label check — `/use-cases/private-runner` shows "Our server"; `/pt-br/use-cases/private-runner` shows "Nosso servidor" + "Seu servidor".
- [x] FAQ entries — Q3 + Q4 each render with link arrows pointing at the right anchors per locale.

## Visual verification (UI changes only)
Verified by HTML inspection on the built dist for `/developers`, `/pt-br/developers`, `/use-cases/private-runner`, and `/pt-br/use-cases/private-runner`. Cross-breakpoint browser verification (375 / 768 / 1024 / 1440), `prefers-reduced-motion` regression check on the new `OAuthIntermediary`, and visual confirmation that the `Nosso servidor` label sits inside the middle box on the rendered SVG are pending — recommend a quick spot-check before merge.

## Notes
- No dependency changes.
- One new visual file (`OAuthIntermediary.astro`); follows the `ControlDataPlanes`/`BeforeAfterTransfer` pattern (SVG + scoped styles, design-system tokens only, `prefers-reduced-motion` collapses pulses to no-op).
- Section surface alternation on `/developers` was re-balanced to keep the rhythm after inserting the new white `#oauth` section: `#api` (soft) → `#oauth` (white, NEW) → `#cli` (soft, was white) → `#runners` (white, was soft) → `#webhooks` (soft, was white) → `#no-sdk` (dark, unchanged).
- This finishes the bespoke-page rewrite series. Homepage, `/plans`, `/self-hosted`, `/developers` are all done. Remaining: the two SEO guide pages from the original rewrite plan's item 7.
