### PR TITLE
feat(waitlist): one-shot rejoin, origin allowlist, polished welcome email

### DIFF
--- a/src/components/sections/WaitlistForm.astro
+++ b/src/components/sections/WaitlistForm.astro
@@ -52,6 +52,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       data-msg-success={t('waitlist.success')}
       data-msg-error-network={t('waitlist.errorNetwork')}
       data-msg-error-rate={t('waitlist.errorRate')}
+      data-msg-error-removed={t('waitlist.errorAlreadyRemoved')}
     ></p>
 
     <div class="waitlist-step2 hidden bg-soft-gray text-left flex flex-col fixed inset-0 z-[60] mt-0 mx-0 max-w-none rounded-none px-6 pt-4 pb-6 overflow-hidden sm:relative sm:inset-auto sm:z-auto sm:mt-10 sm:mx-auto sm:max-w-xl sm:rounded-card sm:p-8 sm:overflow-visible" data-row-id="" data-token="" data-segment-hint={segmentHint ?? ''}>
@@ -95,7 +96,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
 
 <script>
   type Locale = 'en' | 'pt-br';
-  type Stage1Result = { id: string; token: string; status: 'created' | 'existed' };
+  type Stage1Result = { id: string; token: string };
 
   const I18N = {
     en: {
@@ -103,6 +104,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       errorNetwork: "Couldn't reach the server. Try again?",
       errorRate: "Slow down — try again in a minute.",
       errorInvalidEmail: 'Please enter a valid email address.',
+      errorAlreadyRemoved: "This email was already removed from the list. To rejoin, email us at hello@syncologic.com",
       questionUseCase: 'What would you like to do?',
       questionSourceProvider: 'Where do the files live now?',
       questionDestProvider: 'Where do they need to go?',
@@ -127,6 +129,7 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
       errorNetwork: 'Não conseguimos nos conectar ao servidor. Tentar de novo?',
       errorRate: 'Calma — tente de novo em um minuto.',
       errorInvalidEmail: 'Digite um e-mail válido.',
+      errorAlreadyRemoved: 'Este e-mail já foi removido da lista. Para entrar de novo, mande um e-mail para hello@syncologic.com',
       questionUseCase: 'O que você pretende fazer?',
       questionSourceProvider: 'Onde os arquivos estão hoje?',
       questionDestProvider: 'Para onde eles precisam ir?',
@@ -279,11 +282,37 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
     }
 
     const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const TOKEN_RE = /^[0-9a-f]{64}$/i;
 
     const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
     emailInput?.addEventListener('input', () => {
       if (msg.textContent) setMsg('');
     });
+
+    const params = new URLSearchParams(window.location.search);
+    const wlId = params.get('wl_id');
+    const wlToken = params.get('wl_t');
+    const sectionId = root.parentElement?.id;
+    const targetsThisForm = !sectionId || window.location.hash === `#${sectionId}`;
+    if (wlId && wlToken && UUID_RE.test(wlId) && TOKEN_RE.test(wlToken) && targetsThisForm) {
+      step2.dataset.rowId = wlId;
+      step2.dataset.token = wlToken;
+      step2.classList.remove('hidden');
+      form.classList.add('hidden');
+      try {
+        const cached = localStorage.getItem(`waitlist:${wlId}`);
+        if (!cached) {
+          localStorage.setItem(`waitlist:${wlId}`, JSON.stringify({ token: wlToken }));
+        }
+      } catch {}
+      renderStep2(step2, locale);
+      openFullscreen(step2);
+      const url = new URL(window.location.href);
+      url.searchParams.delete('wl_id');
+      url.searchParams.delete('wl_t');
+      window.history.replaceState({}, '', url.toString());
+    }
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -310,6 +339,10 @@ const providerIconMap: Array<{ value: string; logoId: 'google-drive' | 'onedrive
 
         if (res.status === 429) {
           setMsg(I18N[locale].errorRate, 'error');
+          return;
+        }
+        if (res.status === 409) {
+          setMsg(I18N[locale].errorAlreadyRemoved, 'error');
           return;
         }
         if (!res.ok) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -67,6 +67,7 @@
     "success": "✓ You're on the list",
     "errorNetwork": "Couldn't reach the server. Try again?",
     "errorRate": "Slow down — try again in a minute.",
+    "errorAlreadyRemoved": "This email was already removed from the list. To rejoin, email us at hello@syncologic.com",
     "step1Subtitle": "Help us build the right tool. Drop your email, then tell us what you need — it takes about a minute.",
     "step2Title": "Help us build this for you",
     "step2Intro": "7 quick questions.",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -67,6 +67,7 @@
     "success": "✓ Você está na lista",
     "errorNetwork": "Não conseguimos nos conectar ao servidor. Tentar de novo?",
     "errorRate": "Espere um momento — tente de novo em um minuto.",
+    "errorAlreadyRemoved": "Este e-mail já foi removido da lista. Para entrar de novo, mande um e-mail para hello@syncologic.com",
     "step1Subtitle": "Ajude a construir a ferramenta certa. Deixe seu e-mail e conte o que você precisa — leva cerca de um minuto.",
     "step2Title": "Ajude a construir isso para você",
     "step2Intro": "7 perguntas rápidas.",

--- a/src/lib/origin.ts
+++ b/src/lib/origin.ts
@@ -1,0 +1,25 @@
+const ALLOWED_HOSTS = new Set<string>([
+  'syncologic.com',
+  'www.syncologic.com',
+  'syncologic.com.br',
+  'www.syncologic.com.br',
+  'localhost',
+  '127.0.0.1',
+]);
+
+function hostFromHeader(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function isAllowedOrigin(request: Request): boolean {
+  const origin = hostFromHeader(request.headers.get('origin'));
+  if (origin !== null) return ALLOWED_HOSTS.has(origin);
+  const referer = hostFromHeader(request.headers.get('referer'));
+  if (referer !== null) return ALLOWED_HOSTS.has(referer);
+  return false;
+}

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -13,61 +13,130 @@ export const resend = new Resend(apiKey);
 interface ConfirmationParams {
   to: string;
   locale: Locale;
+  siteUrl: string;
   segmentationLink: string;
   unsubscribeLink: string;
 }
 
-const TEMPLATES = {
+interface Copy {
+  preview: string;
+  subject: string;
+  greeting: string;
+  intro: string;
+  segPrompt: string;
+  segCta: string;
+  signoff: string;
+  team: string;
+  unsubPrompt: string;
+  unsubCta: string;
+  logoAlt: string;
+}
+
+const COPY: Record<Locale, Copy> = {
   en: {
-    subject: "You're on the Syncologic waitlist",
-    body: (p: ConfirmationParams) => `
-      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1C2B33; max-width: 560px; margin: 0 auto;">
-        <h1 style="font-size: 20px; font-weight: 500; color: #1C2B33;">Thanks — you're on the waitlist.</h1>
-        <p style="font-size: 16px; line-height: 1.5; color: #5D6C7B;">
-          We'll email you when there's something real to try. No noise in between.
-        </p>
-        <p style="font-size: 16px; line-height: 1.5; color: #5D6C7B;">
-          If you have 30 seconds, <a href="${p.segmentationLink}" style="color: #0064E0;">tell us what you want to move →</a>
-        </p>
-        <p style="font-size: 13px; line-height: 1.5; color: #8595A4; margin-top: 32px;">
-          — The Syncologic team
-        </p>
-        <hr style="border: none; border-top: 1px solid #DEE3E9; margin: 32px 0;" />
-        <p style="font-size: 12px; color: #8595A4;">
-          Didn't sign up? <a href="${p.unsubscribeLink}" style="color: #5D6C7B;">Remove your email</a>.
-        </p>
-      </div>
-    `,
+    preview: "You're in. Welcome to Syncologic.",
+    subject: "Welcome to Syncologic — you're on the waitlist 🎉",
+    greeting: "You're in.",
+    intro:
+      "Thanks for joining the Syncologic waitlist. We're building the calmest way to move files between clouds — and we're genuinely happy you're here. We'll only email when there's something real to try. No noise in between.",
+    segPrompt: 'If you have 30 seconds, help us build the right thing first:',
+    segCta: 'Tell us what you want to move →',
+    signoff: 'Talk soon,',
+    team: 'The Syncologic team',
+    unsubPrompt: "Didn't sign up?",
+    unsubCta: 'Remove your email',
+    logoAlt: 'Syncologic',
   },
   'pt-br': {
-    subject: 'Você está na lista de espera da Syncologic',
-    body: (p: ConfirmationParams) => `
-      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1C2B33; max-width: 560px; margin: 0 auto;">
-        <h1 style="font-size: 20px; font-weight: 500; color: #1C2B33;">Obrigado — você está na lista.</h1>
-        <p style="font-size: 16px; line-height: 1.5; color: #5D6C7B;">
-          Vamos te mandar um e-mail quando tiver algo de verdade para experimentar. Nada de spam.
-        </p>
-        <p style="font-size: 16px; line-height: 1.5; color: #5D6C7B;">
-          Se tiver 30 segundos, <a href="${p.segmentationLink}" style="color: #0064E0;">conta o que você quer transferir →</a>
-        </p>
-        <p style="font-size: 13px; line-height: 1.5; color: #8595A4; margin-top: 32px;">
-          — A equipe da Syncologic
-        </p>
-        <hr style="border: none; border-top: 1px solid #DEE3E9; margin: 32px 0;" />
-        <p style="font-size: 12px; color: #8595A4;">
-          Não foi você? <a href="${p.unsubscribeLink}" style="color: #5D6C7B;">Remover seu e-mail</a>.
-        </p>
-      </div>
-    `,
+    preview: 'Você está dentro. Bem-vindo à Syncologic.',
+    subject: 'Bem-vindo à Syncologic — você está na lista 🎉',
+    greeting: 'Você está dentro.',
+    intro:
+      'Obrigado por entrar na lista de espera da Syncologic. Estamos construindo o jeito mais tranquilo de mover arquivos entre nuvens — e ficamos felizes de verdade com você aqui. Só vamos te escrever quando tiver algo de verdade para experimentar. Nada de spam.',
+    segPrompt: 'Se tiver 30 segundos, nos ajude a construir a coisa certa primeiro:',
+    segCta: 'Conta o que você quer transferir →',
+    signoff: 'Até breve,',
+    team: 'A equipe da Syncologic',
+    unsubPrompt: 'Não foi você?',
+    unsubCta: 'Remover seu e-mail',
+    logoAlt: 'Syncologic',
   },
+};
+
+const COLOR = {
+  text: '#1C2B33',
+  body: '#5D6C7B',
+  muted: '#8595A4',
+  brand: '#0064E0',
+  brandSoft: '#E8F3FF',
+  divider: '#DEE3E9',
+  paper: '#F7F8FA',
 } as const;
 
+function renderEmail(p: ConfirmationParams, c: Copy): string {
+  const logoUrl = `${p.siteUrl}/assets/brand/icon-black.png`;
+  return `<!doctype html>
+<html lang="${p.locale}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${c.subject}</title>
+  </head>
+  <body style="margin:0;padding:0;background:${COLOR.paper};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:${COLOR.text};">
+    <span style="display:none!important;visibility:hidden;opacity:0;color:transparent;height:0;width:0;overflow:hidden;mso-hide:all;">${c.preview}</span>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${COLOR.paper};">
+      <tr>
+        <td align="center" style="padding:40px 16px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background:#FFFFFF;border:1px solid ${COLOR.divider};border-radius:20px;overflow:hidden;">
+            <tr>
+              <td align="center" style="padding:36px 32px 8px 32px;">
+                <img src="${logoUrl}" width="64" height="64" alt="${c.logoAlt}" style="display:block;width:64px;height:64px;border:0;outline:none;text-decoration:none;" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 0 32px;">
+                <h1 style="margin:0 0 12px 0;font-size:26px;line-height:1.25;font-weight:500;color:${COLOR.text};text-align:center;">${c.greeting}</h1>
+                <p style="margin:0 0 20px 0;font-size:16px;line-height:1.6;color:${COLOR.body};text-align:center;">${c.intro}</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:8px 32px 0 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${COLOR.brandSoft};border-radius:16px;">
+                  <tr>
+                    <td style="padding:20px 24px;">
+                      <p style="margin:0 0 12px 0;font-size:15px;line-height:1.5;color:${COLOR.text};">${c.segPrompt}</p>
+                      <a href="${p.segmentationLink}" style="display:inline-block;padding:12px 22px;background:${COLOR.brand};color:#FFFFFF;font-size:15px;font-weight:500;line-height:1;text-decoration:none;border-radius:100px;">${c.segCta}</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <p style="margin:0;font-size:14px;line-height:1.6;color:${COLOR.muted};">${c.signoff}<br/>${c.team}</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 32px 32px 32px;">
+                <hr style="border:none;border-top:1px solid ${COLOR.divider};margin:0 0 16px 0;" />
+                <p style="margin:0;font-size:12px;line-height:1.5;color:${COLOR.muted};">${c.unsubPrompt} <a href="${p.unsubscribeLink}" style="color:${COLOR.body};text-decoration:underline;">${c.unsubCta}</a>.</p>
+              </td>
+            </tr>
+          </table>
+          <p style="margin:24px 0 0 0;font-size:12px;color:${COLOR.muted};">Syncologic</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}
+
 export async function sendWaitlistConfirmation(params: ConfirmationParams): Promise<void> {
-  const tpl = TEMPLATES[params.locale];
+  const copy = COPY[params.locale];
   await resend.emails.send({
     from: fromEmail,
     to: params.to,
-    subject: tpl.subject,
-    html: tpl.body(params),
+    subject: copy.subject,
+    html: renderEmail(params, copy),
   });
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -31,6 +31,7 @@ export type WaitlistRow = {
   segmentation_completed_at: string | null;
   removed_at: string | null;
   confirmed_at: string | null;
+  rejoin_count: number;
   created_at: string;
   updated_at: string;
 };

--- a/src/pages/api/waitlist.ts
+++ b/src/pages/api/waitlist.ts
@@ -4,6 +4,7 @@ import { sendWaitlistConfirmation } from '../../lib/resend';
 import { waitlistPostSchema } from '../../lib/validation';
 import { signToken } from '../../lib/hmac';
 import { hashIp, getClientIp, checkPostBudget } from '../../lib/ratelimit';
+import { isAllowedOrigin } from '../../lib/origin';
 
 export const prerender = false;
 
@@ -15,6 +16,10 @@ function json(data: unknown, status = 200): Response {
 }
 
 export const POST: APIRoute = async ({ request }) => {
+  if (!isAllowedOrigin(request)) {
+    return json({ error: 'forbidden_origin' }, 403);
+  }
+
   let payload: unknown;
   try {
     payload = await request.json();
@@ -45,16 +50,43 @@ export const POST: APIRoute = async ({ request }) => {
 
   const existing = await supabase
     .from('waitlist')
-    .select('id, unsubscribe_token')
+    .select('id, unsubscribe_token, removed_at, rejoin_count')
     .eq('email', email)
     .maybeSingle();
 
   let id: string;
   let unsubscribeToken: string;
+  let shouldSendWelcome = false;
 
   if (existing.data) {
     id = existing.data.id as string;
     unsubscribeToken = existing.data.unsubscribe_token as string;
+    const removedAt = existing.data.removed_at as string | null;
+    const rejoinCount = (existing.data.rejoin_count as number | null) ?? 0;
+
+    if (removedAt) {
+      if (rejoinCount >= 1) {
+        return json({ error: 'already_removed' }, 409);
+      }
+      const rejoin = await supabase
+        .from('waitlist')
+        .update({
+          removed_at: null,
+          rejoin_count: rejoinCount + 1,
+          locale,
+          source_page: source_page ?? null,
+          segment_hint: segment_hint ?? null,
+          user_agent: userAgent,
+          referrer,
+          ip_hash: ipHash,
+        })
+        .eq('id', id);
+      if (rejoin.error) {
+        console.error('waitlist rejoin failed', rejoin.error);
+        return json({ error: 'server_error' }, 500);
+      }
+      shouldSendWelcome = true;
+    }
   } else {
     const inserted = await supabase
       .from('waitlist')
@@ -76,16 +108,23 @@ export const POST: APIRoute = async ({ request }) => {
     }
     id = inserted.data.id as string;
     unsubscribeToken = inserted.data.unsubscribe_token as string;
+    shouldSendWelcome = true;
   }
 
   const token = signToken(id);
   const siteUrl = import.meta.env.PUBLIC_SITE_URL || new URL(request.url).origin;
-  const segmentationLink = `${siteUrl}${source_page ?? '/'}#waitlist?id=${id}&t=${token}`;
+  const segmentationLink = `${siteUrl}${source_page ?? '/'}?wl_id=${id}&wl_t=${token}#waitlist`;
   const unsubscribeLink = `${siteUrl}/api/waitlist/unsubscribe?token=${unsubscribeToken}`;
 
-  sendWaitlistConfirmation({ to: email, locale, segmentationLink, unsubscribeLink }).catch((err) =>
-    console.error('confirmation email failed', err),
-  );
+  if (shouldSendWelcome) {
+    sendWaitlistConfirmation({
+      to: email,
+      locale,
+      siteUrl,
+      segmentationLink,
+      unsubscribeLink,
+    }).catch((err) => console.error('confirmation email failed', err));
+  }
 
-  return json({ id, token, status: existing.data ? 'existed' : 'created' }, 200);
+  return json({ id, token }, 200);
 };

--- a/src/pages/api/waitlist/[id].ts
+++ b/src/pages/api/waitlist/[id].ts
@@ -3,6 +3,7 @@ import { supabase } from '../../../lib/supabase';
 import { waitlistPatchSchema } from '../../../lib/validation';
 import { verifyToken } from '../../../lib/hmac';
 import { hashIp, getClientIp, checkPatchBudget } from '../../../lib/ratelimit';
+import { isAllowedOrigin } from '../../../lib/origin';
 
 export const prerender = false;
 
@@ -14,6 +15,10 @@ function json(data: unknown, status = 200): Response {
 }
 
 export const PATCH: APIRoute = async ({ request, params }) => {
+  if (!isAllowedOrigin(request)) {
+    return json({ error: 'forbidden_origin' }, 403);
+  }
+
   const id = params.id;
   if (!id || !/^[0-9a-f-]{36}$/.test(id)) {
     return json({ error: 'invalid_id' }, 400);

--- a/supabase/migrations/20260506000000_waitlist_rejoin_count.sql
+++ b/supabase/migrations/20260506000000_waitlist_rejoin_count.sql
@@ -1,0 +1,2 @@
+alter table waitlist
+  add column if not exists rejoin_count int not null default 0;


### PR DESCRIPTION
## Summary
- Stop duplicate welcome emails (gate on freshly inserted rows) and add a one-shot rejoin path for users who clicked Unsubscribe by accident — second rejoin returns `409 already_removed`.
- Restrict the waitlist API to `syncologic.com`, `syncologic.com.br`, and `localhost` via an `Origin` / `Referer` allowlist (`POST /api/waitlist`, `PATCH /api/waitlist/[id]`).
- Polish the welcome email (logo header, soft-blue CTA callout, warmer copy in both locales) and make the segmentation link land users straight on step 2 without retyping their email.

## Closes
Closes #160

## Test plan
- [x] `npm run lint`
- [x] `npm test` (51/51)
- [x] `npm run build`
- [x] Apply migration `20260506000000_waitlist_rejoin_count.sql` to the Supabase project before deploying.
- [x] Curl: `POST /api/waitlist` with no `Origin` → 403; with `Origin: https://syncologic.com` → 200/409 as appropriate.
- [x] End-to-end: submit fresh email → 1 welcome; resubmit same email → 0 emails; unsubscribe → resubmit → 1 fresh welcome + `rejoin_count = 1`; resubmit again → 409 with localized error pointing to `hello@syncologic.com`.

## Visual verification (UI changes only)
Visual verification not performed locally — the email logo URL is dev-only broken because `PUBLIC_SITE_URL=http://localhost:4321`; in production the asset URL resolves to `https://syncologic.com/assets/brand/icon-black.png` and renders normally. Form changes (resume from email link, error message) verified via lint + build only — recommend a quick browser pass on Vercel preview before promoting to `main`.

## Notes
- Schema: new `rejoin_count int not null default 0` column on `waitlist`. **Run the migration before deploy** or POSTs will 500 on the new `select`.
- New env-var dependency: none. The origin allowlist is hardcoded to the canonical domains. Vercel preview URLs (`*.vercel.app`) are not allowlisted by design — if previews need to exercise the API, broaden the list in a follow-up.
- The `unsubscribe` GET endpoint is intentionally not gated by the origin allowlist (clicked from emails, where `Origin` / `Referer` are unreliable).
- Drops the unused `status` field from the `POST /api/waitlist` response (`{id, token}` only) since no client read it; HMAC-signed token still required for PATCH.
- No new dependencies.
