### PR TITLE
chore: redirect syncologic.com.br to /pt-br via vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "syncologic.com.br" }],
+      "destination": "https://syncologic.com/pt-br/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
+      "destination": "https://syncologic.com/pt-br/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` with two host-based 308 redirects (`syncologic.com.br` and `www.syncologic.com.br` → `https://syncologic.com/pt-br/...`).
- Path is preserved via `:path*`, so `syncologic.com.br/use-cases/foo` lands on `/pt-br/use-cases/foo`.
- Redirect (not rewrite) keeps a single canonical URL per page, so it doesn't fight `hreflang` or create duplicate-content risk.

## Closes
Closes #162

## Test plan
- [x] `npm run lint` (0 errors, 0 warnings)
- [x] After deploy: `curl -sI https://syncologic.com.br/` → 308 to `https://syncologic.com/pt-br/`
- [x] After deploy: `curl -sI https://syncologic.com.br/use-cases/cloud-to-cloud-transfer` → 308 to `https://syncologic.com/pt-br/use-cases/cloud-to-cloud-transfer`
- [x] After deploy: `curl -sI https://www.syncologic.com.br/` → same behavior

## Visual verification (UI changes only)
Not applicable — config-only change.

## Notes
Both `syncologic.com.br` and `www.syncologic.com.br` need to be attached to the Vercel project for the rule to fire (already done in the dashboard). `syncologic.com` stays the project's primary domain. Reference: [Vercel KB — subdomain to subpath](https://vercel.com/kb/guide/can-i-redirect-from-a-subdomain-to-a-subpath) (KB shows a `rewrites` example; we use `redirects` instead because we want a visible URL change for SEO and i18n correctness).
