### PR TITLE
fix(waitlist): rate-limit GET /api/waitlist/unsubscribe

### DIFF
--- a/src/lib/__tests__/ratelimit.test.ts
+++ b/src/lib/__tests__/ratelimit.test.ts
@@ -40,6 +40,7 @@ import {
   incrementCounter,
   checkPostBudget,
   checkPatchBudget,
+  checkUnsubBudget,
 } from '../ratelimit';
 
 beforeEach(() => {
@@ -142,5 +143,49 @@ describe('checkPatchBudget', () => {
     }
     const blocked = await checkPatchBudget(ip, row);
     expect(blocked.ok).toBe(false);
+  });
+});
+
+describe('checkUnsubBudget', () => {
+  it('allows up to 5 requests per hour, then blocks', async () => {
+    const ip = hashIp('6.6.6.6');
+    for (let i = 0; i < 5; i++) {
+      const r = await checkUnsubBudget(ip);
+      expect(r.ok).toBe(true);
+    }
+    const blocked = await checkUnsubBudget(ip);
+    expect(blocked.ok).toBe(false);
+    expect(blocked.remaining).toBe(0);
+  });
+
+  it('returns decreasing remaining as quota is consumed', async () => {
+    const ip = hashIp('7.7.7.7');
+    const first = await checkUnsubBudget(ip);
+    const second = await checkUnsubBudget(ip);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(second.remaining).toBeLessThan(first.remaining);
+  });
+
+  it('keeps separate IP buckets independent', async () => {
+    const ipA = hashIp('8.8.8.8');
+    const ipB = hashIp('9.9.9.9');
+    for (let i = 0; i < 5; i++) {
+      expect((await checkUnsubBudget(ipA)).ok).toBe(true);
+    }
+    expect((await checkUnsubBudget(ipA)).ok).toBe(false);
+    expect((await checkUnsubBudget(ipB)).ok).toBe(true);
+  });
+
+  it('uses one INCR + one EXPIRE on first hit, INCR-only thereafter', async () => {
+    kvMock.incr.mockClear();
+    kvMock.expire.mockClear();
+    const ip = hashIp('10.10.10.10');
+    await checkUnsubBudget(ip);
+    expect(kvMock.incr).toHaveBeenCalledTimes(1);
+    expect(kvMock.expire).toHaveBeenCalledTimes(1);
+    await checkUnsubBudget(ip);
+    expect(kvMock.incr).toHaveBeenCalledTimes(2);
+    expect(kvMock.expire).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -79,3 +79,11 @@ export async function checkPatchBudget(ipHash: string, rowId: string): Promise<B
 
   return { ok: true, remaining: Math.min(60 - perMin, 200 - perHour, 500 - perDay) };
 }
+
+export async function checkUnsubBudget(ipHash: string): Promise<BudgetCheck> {
+  const hour = new Date().toISOString().slice(0, 13);
+  const perHour = await incrementCounter(`rl:unsub:h:${ipHash}:${hour}`, 3700);
+
+  if (perHour > 5) return { ok: false, remaining: 0 };
+  return { ok: true, remaining: 5 - perHour };
+}

--- a/src/pages/api/waitlist/unsubscribe.ts
+++ b/src/pages/api/waitlist/unsubscribe.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { supabase } from '../../../lib/supabase';
+import { checkUnsubBudget, getClientIp, hashIp } from '../../../lib/ratelimit';
 
 export const prerender = false;
 
@@ -15,7 +16,33 @@ const UNSUB_PAGE = (locale: 'en' | 'pt-br') => {
   return locale === 'pt-br' ? pt : en;
 };
 
-export const GET: APIRoute = async ({ url }) => {
+const TOO_MANY_PAGE = (locale: 'en' | 'pt-br') => {
+  const en = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>Too many requests</title>
+    <style>body{font-family:Montserrat,sans-serif;color:#1C2B33;max-width:480px;margin:80px auto;padding:0 24px;line-height:1.5}</style>
+    </head><body><h1 style="font-weight:500">Too many requests.</h1>
+    <p>Please wait a bit and try the link again.</p></body></html>`;
+  const pt = `<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8"/><title>Muitas tentativas</title>
+    <style>body{font-family:Montserrat,sans-serif;color:#1C2B33;max-width:480px;margin:80px auto;padding:0 24px;line-height:1.5}</style>
+    </head><body><h1 style="font-weight:500">Muitas tentativas.</h1>
+    <p>Aguarde um momento e tente o link novamente.</p></body></html>`;
+  return locale === 'pt-br' ? pt : en;
+};
+
+function preferredLocale(request: Request): 'en' | 'pt-br' {
+  const al = request.headers.get('accept-language') ?? '';
+  return /\bpt(-br)?\b/i.test(al) ? 'pt-br' : 'en';
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const ipHash = hashIp(getClientIp(request));
+  const budget = await checkUnsubBudget(ipHash);
+  if (!budget.ok) {
+    return new Response(TOO_MANY_PAGE(preferredLocale(request)), {
+      status: 429,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  }
+
   const token = url.searchParams.get('token') ?? '';
   if (token && /^[0-9a-f]{32}$/i.test(token)) {
     const result = await supabase


### PR DESCRIPTION
## Summary
- Add `checkUnsubBudget(ipHash)` in `src/lib/ratelimit.ts` — single per-hour bucket, capped at 5/hour per IP, ~1 Redis op per check (one `INCR`, plus one `EXPIRE` on the first hit of the hour).
- Wire it into `GET /api/waitlist/unsubscribe`: counter increments **before** the token regex, so format-rejected requests also count. On block, return **429** with a small locale-aware HTML page (Accept-Language sniff, default `en`).
- Unit tests in `src/lib/__tests__/ratelimit.test.ts` mirror the existing `checkPostBudget` block.

## Closes
Closes #165

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 65 passing (was 61 + 4 new)
- [x] `npm run build`
- [x] Manual: `for i in $(seq 1 8); do curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:4321/api/waitlist/unsubscribe?token=$(openssl rand -hex 16)"; done` → `200 200 200 200 200 429 429 429`
- [x] Manual: 429 body confirmed in both `en` (default) and `pt-br` (via `Accept-Language: pt-BR`)

## Visual verification (UI changes only)
Visual verification not performed — the only HTML surface added is a 429 plain-text fallback page reached programmatically via curl, not a public UI route. Markup is mirrored from the existing `UNSUB_PAGE` style.

## Notes
- No new dependencies.
- Behaviour matches the existing POST/PATCH posture: per-IP Redis counter, hashed IP key. Cross-IP global limits remain out of scope (called out in the issue).
- The 429 is intentionally non-localized in the URL; locale comes from the `Accept-Language` header because the unsubscribe link in emails carries no locale segment. If we ever want stronger locale fidelity here, the unsubscribe URL builder in `src/pages/api/waitlist.ts` is the place to add a `&locale=` param — out of scope for this PR.
