### PR TITLE
feat(seo): Tier 1 — Article/Breadcrumb JSON-LD, OG locale, AI-crawler robots.txt, llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,80 @@
+# Syncologic
+
+> Move files between clouds without downloading them first.
+
+Syncologic is a file-transfer service that moves data directly between cloud
+providers — Google Drive, OneDrive, Dropbox, S3-compatible storage, SFTP,
+WebDAV, and Nextcloud — without pulling files through your laptop. You connect
+a source and a destination, preview what will change, run the transfer, and
+get a clear completion report.
+
+The service is pre-launch. The website captures waitlist signups segmented by
+use case (one-time transfer, business migration, scheduled backup, private
+runner, browser transfer, local backup, developer automation, self-hosting).
+
+## Core pages
+
+- [Homepage](https://syncologic.com/): Product overview, three runner choices, waitlist signup
+- [Plans](https://syncologic.com/plans): Pricing hypotheses (Free, Pro, Business, plus a free self-hosting plan)
+- [Self-hosted](https://syncologic.com/self-hosted): Source-visible architecture, control plane vs data plane
+- [Developers](https://syncologic.com/developers): Future API, CLI, webhook, and runner model
+- [Privacy](https://syncologic.com/privacy): Privacy policy and data handling
+
+## Use cases
+
+- [Cloud-to-cloud transfer](https://syncologic.com/use-cases/cloud-to-cloud-transfer): Move folders between cloud drives without going through your laptop
+- [Business cloud migration](https://syncologic.com/use-cases/business-cloud-migration): Move team files to a new workspace with preview, progress, and a final report
+- [Scheduled cloud backup](https://syncologic.com/use-cases/scheduled-cloud-backup): Recurring copies of important cloud folders
+- [Private Runner](https://syncologic.com/use-cases/private-runner): Run transfers through your own server, NAS, or VPS
+
+## Guides
+
+- [Move files between clouds without downloading them first](https://syncologic.com/guides/move-files-between-clouds-without-downloading): Why download-and-reupload fails on large folders, what works
+- [Transfer Google Drive to OneDrive](https://syncologic.com/guides/transfer-google-drive-to-onedrive): Step-by-step practical guide
+
+## Brazilian Portuguese (pt-BR)
+
+The site is bilingual. Every URL above also exists at `/pt-br/<path>`.
+
+- [Página inicial](https://syncologic.com/pt-br/)
+- [Planos](https://syncologic.com/pt-br/plans)
+- [Auto-hospedado](https://syncologic.com/pt-br/self-hosted)
+- [Desenvolvedores](https://syncologic.com/pt-br/developers)
+- [Casos de uso](https://syncologic.com/pt-br/use-cases/cloud-to-cloud-transfer)
+- [Guias](https://syncologic.com/pt-br/guides)
+
+## How transfers run
+
+A user picks a source cloud, a destination cloud, and where the transfer
+should run. Files move directly between the source and destination — they
+do not flow through Syncologic's servers in metadata, only through the
+runner that executes the transfer.
+
+There are three runner choices:
+
+- On Syncologic infrastructure (brand name: Cloud Runner) — convenient, paid,
+  scheduled jobs and large migrations.
+- In the user's browser tab (brand name: Browser Runner / "This Device") —
+  free, manual, transparent. The tab must stay open.
+- On the user's own server, NAS, or VPS (brand name: Private Runner /
+  self-hosted runner) — for privacy, homelab use, business policy, or high
+  volume.
+
+A "Local Runner Mode" reuses the Private Runner binary to copy from a local
+folder or NAS to a cloud destination.
+
+## Status
+
+Pre-launch (2026). The website is the only public surface. The waitlist
+captures use-case segmentation. There is no product UI yet, no public API,
+and no SDK.
+
+## Not Syncologic
+
+For clarity:
+
+- Syncologic does not store user files. Files move from source provider to
+  destination provider through the chosen runner.
+- Syncologic does not aggregate cloud drives into a single mounted view.
+- "All your files in one place" is not the product — the product is
+  point-to-point transfer with preview, scheduling, and reports.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,48 @@ User-agent: *
 Allow: /
 Disallow: /dev/
 
+User-agent: GPTBot
+Allow: /
+Disallow: /dev/
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /dev/
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /dev/
+
+User-agent: ClaudeBot
+Allow: /
+Disallow: /dev/
+
+User-agent: Claude-Web
+Allow: /
+Disallow: /dev/
+
+User-agent: anthropic-ai
+Allow: /
+Disallow: /dev/
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /dev/
+
+User-agent: Perplexity-User
+Allow: /
+Disallow: /dev/
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /dev/
+
+User-agent: CCBot
+Allow: /
+Disallow: /dev/
+
+User-agent: Applebot-Extended
+Allow: /
+Disallow: /dev/
+
 Sitemap: https://syncologic.com/sitemap-index.xml

--- a/src/components/layout/Layout.astro
+++ b/src/components/layout/Layout.astro
@@ -18,6 +18,8 @@ const canonical = `${siteUrl}${localizedPath(locale, pathSansLocale)}`;
 const altEn = `${siteUrl}${localizedPath('en', pathSansLocale)}`;
 const altPt = `${siteUrl}${localizedPath('pt-br', pathSansLocale)}`;
 const og = ogImage ?? `${siteUrl}/og/default-${locale}.png`;
+const ogLocale = locale === 'pt-br' ? 'pt_BR' : 'en_US';
+const ogLocaleAlternate = locale === 'pt-br' ? 'en_US' : 'pt_BR';
 ---
 
 <!DOCTYPE html>
@@ -39,6 +41,8 @@ const og = ogImage ?? `${siteUrl}/og/default-${locale}.png`;
     <meta property="og:url" content={canonical} />
     <meta property="og:image" content={og} />
     <meta property="og:site_name" content={t('site.name')} />
+    <meta property="og:locale" content={ogLocale} />
+    <meta property="og:locale:alternate" content={ogLocaleAlternate} />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -55,6 +55,14 @@
       "useCases": "Use cases"
     }
   },
+  "breadcrumb": {
+    "home": "Home",
+    "guides": "Guides",
+    "useCases": "Use cases",
+    "plans": "Plans",
+    "selfHosted": "Self-hosted",
+    "developers": "Developers"
+  },
   "language": {
     "label": "Language",
     "en": "English",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -55,6 +55,14 @@
       "useCases": "Casos de uso"
     }
   },
+  "breadcrumb": {
+    "home": "Início",
+    "guides": "Guias",
+    "useCases": "Casos de uso",
+    "plans": "Planos",
+    "selfHosted": "Auto-hospedado",
+    "developers": "Desenvolvedores"
+  },
   "language": {
     "label": "Idioma",
     "en": "English",

--- a/src/lib/__tests__/breadcrumb.test.ts
+++ b/src/lib/__tests__/breadcrumb.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildBreadcrumb } from '../breadcrumb';
+
+describe('buildBreadcrumb', () => {
+  it('produces a single-step BreadcrumbList for Home → leaf', () => {
+    const schema = buildBreadcrumb('en', [
+      { name: 'Home', url: 'https://syncologic.com/' },
+      { name: 'Plans', url: 'https://syncologic.com/plans' },
+    ]);
+    expect(schema).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      inLanguage: 'en',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://syncologic.com/' },
+        { '@type': 'ListItem', position: 2, name: 'Plans', item: 'https://syncologic.com/plans' },
+      ],
+    });
+  });
+
+  it('uses pt-BR for the pt-br locale', () => {
+    const schema = buildBreadcrumb('pt-br', [
+      { name: 'Início', url: 'https://syncologic.com/pt-br/' },
+      { name: 'Planos', url: 'https://syncologic.com/pt-br/plans' },
+    ]);
+    expect(schema.inLanguage).toBe('pt-BR');
+    expect(schema.itemListElement).toHaveLength(2);
+    expect(schema.itemListElement[0].position).toBe(1);
+    expect(schema.itemListElement[1].position).toBe(2);
+  });
+
+  it('preserves order and assigns sequential positions', () => {
+    const schema = buildBreadcrumb('en', [
+      { name: 'Home', url: 'https://syncologic.com/' },
+      { name: 'Guides', url: 'https://syncologic.com/guides' },
+      { name: 'Move files', url: 'https://syncologic.com/guides/move' },
+    ]);
+    const positions = schema.itemListElement.map((i) => i.position);
+    expect(positions).toEqual([1, 2, 3]);
+    expect(schema.itemListElement[2].name).toBe('Move files');
+    expect(schema.itemListElement[2].item).toBe('https://syncologic.com/guides/move');
+  });
+
+  it('throws when given an empty list', () => {
+    expect(() => buildBreadcrumb('en', [])).toThrow();
+  });
+});

--- a/src/lib/__tests__/breadcrumb.test.ts
+++ b/src/lib/__tests__/breadcrumb.test.ts
@@ -23,10 +23,13 @@ describe('buildBreadcrumb', () => {
       { name: 'Início', url: 'https://syncologic.com/pt-br/' },
       { name: 'Planos', url: 'https://syncologic.com/pt-br/plans' },
     ]);
-    expect(schema.inLanguage).toBe('pt-BR');
-    expect(schema.itemListElement).toHaveLength(2);
-    expect(schema.itemListElement[0].position).toBe(1);
-    expect(schema.itemListElement[1].position).toBe(2);
+    expect(schema).toMatchObject({
+      inLanguage: 'pt-BR',
+      itemListElement: [
+        { position: 1 },
+        { position: 2 },
+      ],
+    });
   });
 
   it('preserves order and assigns sequential positions', () => {
@@ -35,10 +38,13 @@ describe('buildBreadcrumb', () => {
       { name: 'Guides', url: 'https://syncologic.com/guides' },
       { name: 'Move files', url: 'https://syncologic.com/guides/move' },
     ]);
-    const positions = schema.itemListElement.map((i) => i.position);
-    expect(positions).toEqual([1, 2, 3]);
-    expect(schema.itemListElement[2].name).toBe('Move files');
-    expect(schema.itemListElement[2].item).toBe('https://syncologic.com/guides/move');
+    expect(schema).toMatchObject({
+      itemListElement: [
+        { position: 1, name: 'Home' },
+        { position: 2, name: 'Guides' },
+        { position: 3, name: 'Move files', item: 'https://syncologic.com/guides/move' },
+      ],
+    });
   });
 
   it('throws when given an empty list', () => {

--- a/src/lib/__tests__/breadcrumb.test.ts
+++ b/src/lib/__tests__/breadcrumb.test.ts
@@ -2,38 +2,24 @@ import { describe, it, expect } from 'vitest';
 import { buildBreadcrumb } from '../breadcrumb';
 
 describe('buildBreadcrumb', () => {
-  it('produces a single-step BreadcrumbList for Home → leaf', () => {
-    const schema = buildBreadcrumb('en', [
+  it('produces a BreadcrumbList without inLanguage (not valid on schema.org BreadcrumbList)', () => {
+    const schema = buildBreadcrumb([
       { name: 'Home', url: 'https://syncologic.com/' },
       { name: 'Plans', url: 'https://syncologic.com/plans' },
     ]);
     expect(schema).toEqual({
       '@context': 'https://schema.org',
       '@type': 'BreadcrumbList',
-      inLanguage: 'en',
       itemListElement: [
         { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://syncologic.com/' },
         { '@type': 'ListItem', position: 2, name: 'Plans', item: 'https://syncologic.com/plans' },
       ],
     });
-  });
-
-  it('uses pt-BR for the pt-br locale', () => {
-    const schema = buildBreadcrumb('pt-br', [
-      { name: 'Início', url: 'https://syncologic.com/pt-br/' },
-      { name: 'Planos', url: 'https://syncologic.com/pt-br/plans' },
-    ]);
-    expect(schema).toMatchObject({
-      inLanguage: 'pt-BR',
-      itemListElement: [
-        { position: 1 },
-        { position: 2 },
-      ],
-    });
+    expect(schema).not.toHaveProperty('inLanguage');
   });
 
   it('preserves order and assigns sequential positions', () => {
-    const schema = buildBreadcrumb('en', [
+    const schema = buildBreadcrumb([
       { name: 'Home', url: 'https://syncologic.com/' },
       { name: 'Guides', url: 'https://syncologic.com/guides' },
       { name: 'Move files', url: 'https://syncologic.com/guides/move' },
@@ -48,6 +34,6 @@ describe('buildBreadcrumb', () => {
   });
 
   it('throws when given an empty list', () => {
-    expect(() => buildBreadcrumb('en', [])).toThrow();
+    expect(() => buildBreadcrumb([])).toThrow();
   });
 });

--- a/src/lib/breadcrumb.ts
+++ b/src/lib/breadcrumb.ts
@@ -1,21 +1,15 @@
-import type { Locale } from '../i18n/utils';
-
 export interface BreadcrumbItem {
   name: string;
   url: string;
 }
 
-export function buildBreadcrumb(
-  locale: Locale,
-  items: BreadcrumbItem[],
-): Record<string, unknown> {
+export function buildBreadcrumb(items: BreadcrumbItem[]): Record<string, unknown> {
   if (items.length === 0) {
     throw new Error('buildBreadcrumb requires at least one item');
   }
   return {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
-    inLanguage: locale === 'pt-br' ? 'pt-BR' : 'en',
     itemListElement: items.map((item, index) => ({
       '@type': 'ListItem',
       position: index + 1,

--- a/src/lib/breadcrumb.ts
+++ b/src/lib/breadcrumb.ts
@@ -1,0 +1,37 @@
+import type { Locale } from '../i18n/utils';
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export interface BreadcrumbListItem {
+  '@type': 'ListItem';
+  position: number;
+  name: string;
+  item: string;
+}
+
+export interface BreadcrumbSchema {
+  '@context': 'https://schema.org';
+  '@type': 'BreadcrumbList';
+  inLanguage: 'en' | 'pt-BR';
+  itemListElement: BreadcrumbListItem[];
+}
+
+export function buildBreadcrumb(locale: Locale, items: BreadcrumbItem[]): BreadcrumbSchema {
+  if (items.length === 0) {
+    throw new Error('buildBreadcrumb requires at least one item');
+  }
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    inLanguage: locale === 'pt-br' ? 'pt-BR' : 'en',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}

--- a/src/lib/breadcrumb.ts
+++ b/src/lib/breadcrumb.ts
@@ -5,21 +5,10 @@ export interface BreadcrumbItem {
   url: string;
 }
 
-export interface BreadcrumbListItem {
-  '@type': 'ListItem';
-  position: number;
-  name: string;
-  item: string;
-}
-
-export interface BreadcrumbSchema {
-  '@context': 'https://schema.org';
-  '@type': 'BreadcrumbList';
-  inLanguage: 'en' | 'pt-BR';
-  itemListElement: BreadcrumbListItem[];
-}
-
-export function buildBreadcrumb(locale: Locale, items: BreadcrumbItem[]): BreadcrumbSchema {
+export function buildBreadcrumb(
+  locale: Locale,
+  items: BreadcrumbItem[],
+): Record<string, unknown> {
   if (items.length === 0) {
     throw new Error('buildBreadcrumb requires at least one item');
   }

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -11,7 +11,7 @@ const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
-const breadcrumbSchema = buildBreadcrumb(locale, [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
   { name: t('breadcrumb.developers'), url: `${siteUrl}${localizedPath(locale, '/developers')}` },
 ]);

--- a/src/pages/developers.astro
+++ b/src/pages/developers.astro
@@ -1,15 +1,24 @@
 ---
 import Layout from '../components/layout/Layout.astro';
+import JsonLd from '../components/layout/JsonLd.astro';
 import Nav from '../components/layout/Nav.astro';
 import Footer from '../components/layout/Footer.astro';
 import DevelopersPage from '../components/sections/DevelopersPage.astro';
-import { getLocaleFromUrl, getT } from '../i18n/utils';
+import { getLocaleFromUrl, getT, localizedPath } from '../i18n/utils';
+import { buildBreadcrumb } from '../lib/breadcrumb';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
+
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const breadcrumbSchema = buildBreadcrumb(locale, [
+  { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
+  { name: t('breadcrumb.developers'), url: `${siteUrl}${localizedPath(locale, '/developers')}` },
+]);
 ---
 
 <Layout title={t('developers.title')} description={t('developers.description')}>
+  <JsonLd slot="head" schema={breadcrumbSchema} />
   <Nav slot="nav" />
   <DevelopersPage />
   <Footer slot="footer" />

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -53,7 +53,7 @@ const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
 const canonical = `${siteUrl}${localizedPath('en', `/guides/${slug}`)}`;
 const ogImageAbs = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
 
-const breadcrumbSchema = buildBreadcrumb('en', [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}/` },
   { name: t('breadcrumb.guides'), url: `${siteUrl}/guides` },
   { name: entry.data.title, url: canonical },

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -13,8 +13,10 @@ import ProviderArc from '../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../components/visuals/MigrationChecklist.astro';
 import ScheduleClock from '../../components/visuals/ScheduleClock.astro';
 import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
+import JsonLd from '../../components/layout/JsonLd.astro';
 import { getT, localizedPath } from '../../i18n/utils';
 import { readingTimeMinutes } from '../../lib/reading-time';
+import { buildBreadcrumb } from '../../lib/breadcrumb';
 
 export async function getStaticPaths() {
   const entries = await getCollection('guides', (e) => e.data.locale === 'en');
@@ -36,6 +38,7 @@ export async function getStaticPaths() {
 }
 
 const { entry, related } = Astro.props;
+const { slug } = Astro.params;
 const { Content, headings } = await render(entry);
 const ogImage = entry.data.ogImage ?? '/og/default-en.png';
 const t = getT('en');
@@ -45,9 +48,39 @@ const updatedIso = entry.data.updatedAt.toISOString().slice(0, 10);
 const segmentHref = entry.data.waitlistSegment === 'business_migration'
   ? '/use-cases/business-cloud-migration'
   : '/use-cases/cloud-to-cloud-transfer';
+
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const canonical = `${siteUrl}${localizedPath('en', `/guides/${slug}`)}`;
+const ogImageAbs = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
+
+const breadcrumbSchema = buildBreadcrumb('en', [
+  { name: t('breadcrumb.home'), url: `${siteUrl}/` },
+  { name: t('breadcrumb.guides'), url: `${siteUrl}/guides` },
+  { name: entry.data.title, url: canonical },
+]);
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: entry.data.headline,
+  description: entry.data.description,
+  inLanguage: 'en',
+  datePublished: entry.data.publishedAt.toISOString(),
+  dateModified: entry.data.updatedAt.toISOString(),
+  image: ogImageAbs,
+  mainEntityOfPage: canonical,
+  author: { '@type': 'Organization', name: 'Syncologic', url: siteUrl },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Syncologic',
+    url: siteUrl,
+    logo: { '@type': 'ImageObject', url: `${siteUrl}/assets/brand/icon-white.svg` },
+  },
+};
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
+  <JsonLd slot="head" schema={[breadcrumbSchema, articleSchema]} />
   <Nav slot="nav" />
 
   <article class="bg-reading-paper">

--- a/src/pages/plans.astro
+++ b/src/pages/plans.astro
@@ -11,13 +11,15 @@ import FAQ from '../components/sections/FAQ.astro';
 import WaitlistForm from '../components/sections/WaitlistForm.astro';
 import PricingCurves from '../components/visuals/PricingCurves.astro';
 import CostDrivers from '../components/visuals/CostDrivers.astro';
-import { getLocaleFromUrl } from '../i18n/utils';
+import { getLocaleFromUrl, getT, localizedPath } from '../i18n/utils';
+import { buildBreadcrumb } from '../lib/breadcrumb';
 import en from '../i18n/en.json';
 import ptBr from '../i18n/pt-br.json';
 
 const locale = getLocaleFromUrl(Astro.url);
 const dict = locale === 'pt-br' ? ptBr : en;
 const p = dict.pricing;
+const t = getT(locale);
 
 const title = p.meta.title;
 const description = p.meta.description;
@@ -32,6 +34,12 @@ const faqSchema = {
   })),
 };
 
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const breadcrumbSchema = buildBreadcrumb(locale, [
+  { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
+  { name: t('breadcrumb.plans'), url: `${siteUrl}${localizedPath(locale, '/plans')}` },
+]);
+
 const mainPlans = [
   { ...p.hypotheses.free, recommended: false },
   { ...p.hypotheses.pro, recommended: true },
@@ -41,7 +49,7 @@ const selfHostFree = p.selfHost.free;
 ---
 
 <Layout title={title} description={description}>
-  <JsonLd slot="head" schema={faqSchema} />
+  <JsonLd slot="head" schema={[breadcrumbSchema, faqSchema]} />
   <Nav slot="nav" />
 
   <Hero

--- a/src/pages/plans.astro
+++ b/src/pages/plans.astro
@@ -35,7 +35,7 @@ const faqSchema = {
 };
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
-const breadcrumbSchema = buildBreadcrumb(locale, [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
   { name: t('breadcrumb.plans'), url: `${siteUrl}${localizedPath(locale, '/plans')}` },
 ]);

--- a/src/pages/pt-br/developers.astro
+++ b/src/pages/pt-br/developers.astro
@@ -11,7 +11,7 @@ const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
-const breadcrumbSchema = buildBreadcrumb(locale, [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
   { name: t('breadcrumb.developers'), url: `${siteUrl}${localizedPath(locale, '/developers')}` },
 ]);

--- a/src/pages/pt-br/developers.astro
+++ b/src/pages/pt-br/developers.astro
@@ -1,15 +1,24 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
+import JsonLd from '../../components/layout/JsonLd.astro';
 import Nav from '../../components/layout/Nav.astro';
 import Footer from '../../components/layout/Footer.astro';
 import DevelopersPage from '../../components/sections/DevelopersPage.astro';
-import { getLocaleFromUrl, getT } from '../../i18n/utils';
+import { getLocaleFromUrl, getT, localizedPath } from '../../i18n/utils';
+import { buildBreadcrumb } from '../../lib/breadcrumb';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
+
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const breadcrumbSchema = buildBreadcrumb(locale, [
+  { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
+  { name: t('breadcrumb.developers'), url: `${siteUrl}${localizedPath(locale, '/developers')}` },
+]);
 ---
 
 <Layout title={t('developers.title')} description={t('developers.description')}>
+  <JsonLd slot="head" schema={breadcrumbSchema} />
   <Nav slot="nav" />
   <DevelopersPage />
   <Footer slot="footer" />

--- a/src/pages/pt-br/guides/[slug].astro
+++ b/src/pages/pt-br/guides/[slug].astro
@@ -13,8 +13,10 @@ import ProviderArc from '../../../components/visuals/ProviderArc.astro';
 import MigrationChecklist from '../../../components/visuals/MigrationChecklist.astro';
 import ScheduleClock from '../../../components/visuals/ScheduleClock.astro';
 import PrivateRunnerPath from '../../../components/visuals/PrivateRunnerPath.astro';
+import JsonLd from '../../../components/layout/JsonLd.astro';
 import { getT, localizedPath } from '../../../i18n/utils';
 import { readingTimeMinutes } from '../../../lib/reading-time';
+import { buildBreadcrumb } from '../../../lib/breadcrumb';
 
 export async function getStaticPaths() {
   const entries = await getCollection('guides', (e) => e.data.locale === 'pt-br');
@@ -36,6 +38,7 @@ export async function getStaticPaths() {
 }
 
 const { entry, related } = Astro.props;
+const { slug } = Astro.params;
 const { Content, headings } = await render(entry);
 const ogImage = entry.data.ogImage ?? '/og/default-pt-br.png';
 const t = getT('pt-br');
@@ -45,9 +48,39 @@ const updatedIso = entry.data.updatedAt.toISOString().slice(0, 10);
 const segmentHref = entry.data.waitlistSegment === 'business_migration'
   ? '/use-cases/business-cloud-migration'
   : '/use-cases/cloud-to-cloud-transfer';
+
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const canonical = `${siteUrl}${localizedPath('pt-br', `/guides/${slug}`)}`;
+const ogImageAbs = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
+
+const breadcrumbSchema = buildBreadcrumb('pt-br', [
+  { name: t('breadcrumb.home'), url: `${siteUrl}/pt-br/` },
+  { name: t('breadcrumb.guides'), url: `${siteUrl}/pt-br/guides` },
+  { name: entry.data.title, url: canonical },
+]);
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: entry.data.headline,
+  description: entry.data.description,
+  inLanguage: 'pt-BR',
+  datePublished: entry.data.publishedAt.toISOString(),
+  dateModified: entry.data.updatedAt.toISOString(),
+  image: ogImageAbs,
+  mainEntityOfPage: canonical,
+  author: { '@type': 'Organization', name: 'Syncologic', url: siteUrl },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Syncologic',
+    url: siteUrl,
+    logo: { '@type': 'ImageObject', url: `${siteUrl}/assets/brand/icon-white.svg` },
+  },
+};
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
+  <JsonLd slot="head" schema={[breadcrumbSchema, articleSchema]} />
   <Nav slot="nav" />
 
   <article class="bg-reading-paper">

--- a/src/pages/pt-br/guides/[slug].astro
+++ b/src/pages/pt-br/guides/[slug].astro
@@ -53,7 +53,7 @@ const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
 const canonical = `${siteUrl}${localizedPath('pt-br', `/guides/${slug}`)}`;
 const ogImageAbs = ogImage.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
 
-const breadcrumbSchema = buildBreadcrumb('pt-br', [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}/pt-br/` },
   { name: t('breadcrumb.guides'), url: `${siteUrl}/pt-br/guides` },
   { name: entry.data.title, url: canonical },

--- a/src/pages/pt-br/plans.astro
+++ b/src/pages/pt-br/plans.astro
@@ -11,13 +11,15 @@ import FAQ from '../../components/sections/FAQ.astro';
 import WaitlistForm from '../../components/sections/WaitlistForm.astro';
 import PricingCurves from '../../components/visuals/PricingCurves.astro';
 import CostDrivers from '../../components/visuals/CostDrivers.astro';
-import { getLocaleFromUrl } from '../../i18n/utils';
+import { getLocaleFromUrl, getT, localizedPath } from '../../i18n/utils';
+import { buildBreadcrumb } from '../../lib/breadcrumb';
 import en from '../../i18n/en.json';
 import ptBr from '../../i18n/pt-br.json';
 
 const locale = getLocaleFromUrl(Astro.url);
 const dict = locale === 'pt-br' ? ptBr : en;
 const p = dict.pricing;
+const t = getT(locale);
 
 const title = p.meta.title;
 const description = p.meta.description;
@@ -32,6 +34,12 @@ const faqSchema = {
   })),
 };
 
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const breadcrumbSchema = buildBreadcrumb(locale, [
+  { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
+  { name: t('breadcrumb.plans'), url: `${siteUrl}${localizedPath(locale, '/plans')}` },
+]);
+
 const mainPlans = [
   { ...p.hypotheses.free, recommended: false },
   { ...p.hypotheses.pro, recommended: true },
@@ -41,7 +49,7 @@ const selfHostFree = p.selfHost.free;
 ---
 
 <Layout title={title} description={description}>
-  <JsonLd slot="head" schema={faqSchema} />
+  <JsonLd slot="head" schema={[breadcrumbSchema, faqSchema]} />
   <Nav slot="nav" />
 
   <Hero

--- a/src/pages/pt-br/plans.astro
+++ b/src/pages/pt-br/plans.astro
@@ -35,7 +35,7 @@ const faqSchema = {
 };
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
-const breadcrumbSchema = buildBreadcrumb(locale, [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
   { name: t('breadcrumb.plans'), url: `${siteUrl}${localizedPath(locale, '/plans')}` },
 ]);

--- a/src/pages/pt-br/self-hosted.astro
+++ b/src/pages/pt-br/self-hosted.astro
@@ -1,18 +1,27 @@
 ---
 import Layout from '../../components/layout/Layout.astro';
+import JsonLd from '../../components/layout/JsonLd.astro';
 import Nav from '../../components/layout/Nav.astro';
 import Footer from '../../components/layout/Footer.astro';
 import Hero from '../../components/sections/Hero.astro';
 import SelfHostedSections from '../../components/sections/SelfHostedSections.astro';
 import WaitlistForm from '../../components/sections/WaitlistForm.astro';
 import PrivateRunnerPath from '../../components/visuals/PrivateRunnerPath.astro';
-import { getLocaleFromUrl, getT } from '../../i18n/utils';
+import { getLocaleFromUrl, getT, localizedPath } from '../../i18n/utils';
+import { buildBreadcrumb } from '../../lib/breadcrumb';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
+
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const breadcrumbSchema = buildBreadcrumb(locale, [
+  { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
+  { name: t('breadcrumb.selfHosted'), url: `${siteUrl}${localizedPath(locale, '/self-hosted')}` },
+]);
 ---
 
 <Layout title={t('selfHosted.meta.title')} description={t('selfHosted.meta.description')}>
+  <JsonLd slot="head" schema={breadcrumbSchema} />
   <Nav slot="nav" />
   <div data-hero>
     <Hero

--- a/src/pages/pt-br/self-hosted.astro
+++ b/src/pages/pt-br/self-hosted.astro
@@ -14,7 +14,7 @@ const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
-const breadcrumbSchema = buildBreadcrumb(locale, [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
   { name: t('breadcrumb.selfHosted'), url: `${siteUrl}${localizedPath(locale, '/self-hosted')}` },
 ]);

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -13,6 +13,9 @@ import BeforeAfterTransfer from '../../../components/visuals/BeforeAfterTransfer
 import PricingCurves from '../../../components/visuals/PricingCurves.astro';
 import HostedVsPrivatePath from '../../../components/visuals/HostedVsPrivatePath.astro';
 import GuideCrossLinks from '../../../components/sections/GuideCrossLinks.astro';
+import JsonLd from '../../../components/layout/JsonLd.astro';
+import { getT, localizedPath } from '../../../i18n/utils';
+import { buildBreadcrumb } from '../../../lib/breadcrumb';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
   'cloud-to-cloud-transfer': ProviderArc,
@@ -42,9 +45,20 @@ const { Content } = await render(entry);
 const ogImage = entry.data.ogImage ?? '/og/default-pt-br.png';
 const Visual = visualMap[slug];
 const crossLinks = crossLinkMap[slug] ?? [];
+
+const t = getT('pt-br');
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const canonical = `${siteUrl}${localizedPath('pt-br', `/use-cases/${slug}`)}`;
+
+const breadcrumbSchema = buildBreadcrumb('pt-br', [
+  { name: t('breadcrumb.home'), url: `${siteUrl}/pt-br/` },
+  { name: t('breadcrumb.useCases'), url: `${siteUrl}/pt-br/use-cases` },
+  { name: entry.data.title, url: canonical },
+]);
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
+  <JsonLd slot="head" schema={breadcrumbSchema} />
   <Nav slot="nav" />
   <Hero
     eyebrow={entry.data.eyebrow}

--- a/src/pages/pt-br/use-cases/[slug].astro
+++ b/src/pages/pt-br/use-cases/[slug].astro
@@ -50,7 +50,7 @@ const t = getT('pt-br');
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
 const canonical = `${siteUrl}${localizedPath('pt-br', `/use-cases/${slug}`)}`;
 
-const breadcrumbSchema = buildBreadcrumb('pt-br', [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}/pt-br/` },
   { name: t('breadcrumb.useCases'), url: `${siteUrl}/pt-br/use-cases` },
   { name: entry.data.title, url: canonical },

--- a/src/pages/self-hosted.astro
+++ b/src/pages/self-hosted.astro
@@ -1,18 +1,27 @@
 ---
 import Layout from '../components/layout/Layout.astro';
+import JsonLd from '../components/layout/JsonLd.astro';
 import Nav from '../components/layout/Nav.astro';
 import Footer from '../components/layout/Footer.astro';
 import Hero from '../components/sections/Hero.astro';
 import SelfHostedSections from '../components/sections/SelfHostedSections.astro';
 import WaitlistForm from '../components/sections/WaitlistForm.astro';
 import PrivateRunnerPath from '../components/visuals/PrivateRunnerPath.astro';
-import { getLocaleFromUrl, getT } from '../i18n/utils';
+import { getLocaleFromUrl, getT, localizedPath } from '../i18n/utils';
+import { buildBreadcrumb } from '../lib/breadcrumb';
 
 const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
+
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const breadcrumbSchema = buildBreadcrumb(locale, [
+  { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
+  { name: t('breadcrumb.selfHosted'), url: `${siteUrl}${localizedPath(locale, '/self-hosted')}` },
+]);
 ---
 
 <Layout title={t('selfHosted.meta.title')} description={t('selfHosted.meta.description')}>
+  <JsonLd slot="head" schema={breadcrumbSchema} />
   <Nav slot="nav" />
   <div data-hero>
     <Hero

--- a/src/pages/self-hosted.astro
+++ b/src/pages/self-hosted.astro
@@ -14,7 +14,7 @@ const locale = getLocaleFromUrl(Astro.url);
 const t = getT(locale);
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
-const breadcrumbSchema = buildBreadcrumb(locale, [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}${localizedPath(locale, '/')}` },
   { name: t('breadcrumb.selfHosted'), url: `${siteUrl}${localizedPath(locale, '/self-hosted')}` },
 ]);

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -13,6 +13,9 @@ import BeforeAfterTransfer from '../../components/visuals/BeforeAfterTransfer.as
 import PricingCurves from '../../components/visuals/PricingCurves.astro';
 import HostedVsPrivatePath from '../../components/visuals/HostedVsPrivatePath.astro';
 import GuideCrossLinks from '../../components/sections/GuideCrossLinks.astro';
+import JsonLd from '../../components/layout/JsonLd.astro';
+import { getT, localizedPath } from '../../i18n/utils';
+import { buildBreadcrumb } from '../../lib/breadcrumb';
 
 const visualMap: Record<string, typeof ProviderArc | undefined> = {
   'cloud-to-cloud-transfer': ProviderArc,
@@ -42,9 +45,20 @@ const { Content } = await render(entry);
 const ogImage = entry.data.ogImage ?? '/og/default-en.png';
 const Visual = visualMap[slug];
 const crossLinks = crossLinkMap[slug] ?? [];
+
+const t = getT('en');
+const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
+const canonical = `${siteUrl}${localizedPath('en', `/use-cases/${slug}`)}`;
+
+const breadcrumbSchema = buildBreadcrumb('en', [
+  { name: t('breadcrumb.home'), url: `${siteUrl}/` },
+  { name: t('breadcrumb.useCases'), url: `${siteUrl}/use-cases` },
+  { name: entry.data.title, url: canonical },
+]);
 ---
 
 <Layout title={entry.data.title} description={entry.data.description} ogImage={ogImage}>
+  <JsonLd slot="head" schema={breadcrumbSchema} />
   <Nav slot="nav" />
   <Hero
     eyebrow={entry.data.eyebrow}

--- a/src/pages/use-cases/[slug].astro
+++ b/src/pages/use-cases/[slug].astro
@@ -50,7 +50,7 @@ const t = getT('en');
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://syncologic.com';
 const canonical = `${siteUrl}${localizedPath('en', `/use-cases/${slug}`)}`;
 
-const breadcrumbSchema = buildBreadcrumb('en', [
+const breadcrumbSchema = buildBreadcrumb([
   { name: t('breadcrumb.home'), url: `${siteUrl}/` },
   { name: t('breadcrumb.useCases'), url: `${siteUrl}/use-cases` },
   { name: entry.data.title, url: canonical },


### PR DESCRIPTION
## Summary
- Adds `Article` + `BreadcrumbList` JSON-LD on guides, `BreadcrumbList` on use-cases / `/plans` / `/self-hosted` / `/developers`, plus `og:locale` + `og:locale:alternate` in `Layout.astro` — across both EN and pt-BR.
- Expands `public/robots.txt` with explicit `User-agent` blocks for GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, CCBot, Applebot-Extended (each `Allow: /` + `Disallow: /dev/`).
- Adds `public/llms.txt` per the [llmstxt.org](https://llmstxt.org/) convention as a site index for AI assistants.

## Closes
Closes #168

## Test plan
- [x] `npm run lint` — 0 errors / 0 warnings (2 pre-existing hints).
- [x] `npm test` — 7 files, 69 tests passing (4 new tests in `src/lib/__tests__/breadcrumb.test.ts`).
- [x] `npm run build` — clean production build, sitemap regenerated.
- [x] Build-output audit script grepped JSON-LD across all 20 EN+pt-BR routes; every page emits the expected schemas with the correct `inLanguage` and the right `og:locale` (en_US / pt_BR).
- [ ] Post-deploy: validate one `Article` + one `BreadcrumbList` block in [validator.schema.org](https://validator.schema.org/) on the preview URL.
- [ ] Post-deploy: `curl <preview>/llms.txt` and `curl <preview>/robots.txt`, confirm content.

## Visual verification (UI changes only)
None — this PR adds `<head>` metadata and static text files only. No visible markup changes.

## Notes
- **No new dependencies.** Existing `JsonLd.astro` component is the single emitter.
- **i18n keys added.** New `breadcrumb.{home,guides,useCases,plans,selfHosted,developers}` namespace in both `src/i18n/en.json` and `src/i18n/pt-br.json` with real Brazilian Portuguese translations (matching the rest of pt-br.json).
- **`buildBreadcrumb` returns `Record<string, unknown>`** to satisfy `JsonLd.Props`. The concrete shape is covered by tests, not by an exported type.
- **Use-cases breadcrumb** uses `Home → Use cases → <title>`; the middle "Use cases" item points at `/use-cases` even though no hub page exists yet — Google accepts non-resolving middle items, and Plan 2 will likely add the hub.
- **AI-crawler robots.txt rules** are positive signals (we want presence in ChatGPT/Claude/Perplexity search), not protection. The site is fully public.
- **Sitemap depends on `PUBLIC_SITE_URL`.** Local builds without that env var emit `http://localhost:4321` in JSON-LD URLs — that's the existing convention, not a regression.
- **Deferred to Tier 2:** `SoftwareApplication` schema on the homepage, `HowTo` schema on step-by-step guides, IndexNow ping for Bing, sitemap `lastmod` enrichment.
