### PR TITLE
feat(plans): inline link from self-host card to under-the-hood explainer

### DIFF
--- a/src/components/sections/SelfHostedSections.astro
+++ b/src/components/sections/SelfHostedSections.astro
@@ -37,7 +37,7 @@ const roadmapLevels = ['level1', 'level2'] as const;
 </Section>
 
 <Section surface="soft" padding="lg">
-  <details class="group max-w-[1040px] mx-auto self-hosted-details">
+  <details id="under-the-hood" class="group max-w-[1040px] mx-auto self-hosted-details scroll-mt-24">
     <summary class="flex items-center justify-between gap-4 cursor-pointer rounded-card bg-white border border-divider px-6 py-5 text-h3 font-bold text-dark-charcoal hover:border-slate-gray transition-colors">
       <span>{t('selfHosted.underTheHood.summary')}</span>
       <ChevronDown size={20} class="shrink-0 transition-transform duration-200 group-open:rotate-180 text-slate-gray" />
@@ -120,3 +120,16 @@ const roadmapLevels = ['level1', 'level2'] as const;
     display: none;
   }
 </style>
+
+<script>
+  function openUnderTheHoodFromHash() {
+    if (window.location.hash !== '#under-the-hood') return;
+    const el = document.getElementById('under-the-hood');
+    if (el instanceof HTMLDetailsElement) {
+      el.open = true;
+      el.scrollIntoView({ block: 'start' });
+    }
+  }
+  openUnderTheHoodFromHash();
+  window.addEventListener('hashchange', openUnderTheHoodFromHash);
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -377,7 +377,8 @@
         ],
         "footnote": "30-day run history. Unlimited runners. Single-user during early access."
       },
-      "title": "Self-host the data path"
+      "title": "Self-host the data path",
+      "controlPlaneLink": "Don't know what a control plane is?"
     },
     "affects": {
       "title": "What affects cost",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -377,7 +377,8 @@
         ],
         "footnote": "Histórico de execuções de 30 dias. Runners ilimitados. Usuário único durante o acesso antecipado."
       },
-      "title": "Auto-hospede o caminho dos dados"
+      "title": "Auto-hospede o caminho dos dados",
+      "controlPlaneLink": "Não sabe o que é um control plane?"
     },
     "affects": {
       "title": "O que afeta o custo",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -378,7 +378,7 @@
         "footnote": "Histórico de execuções de 30 dias. Runners ilimitados. Usuário único durante o acesso antecipado."
       },
       "title": "Auto-hospede o caminho dos dados",
-      "controlPlaneLink": "Não sabe o que é um control plane?"
+      "controlPlaneLink": "Não sabe o que é a camada de controle?"
     },
     "affects": {
       "title": "O que afeta o custo",

--- a/src/pages/plans.astro
+++ b/src/pages/plans.astro
@@ -123,7 +123,15 @@ const selfHostFree = p.selfHost.free;
         </div>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-10">
-        <p class="text-body text-dark-charcoal leading-snug">{selfHostFree.description}</p>
+        <div class="flex flex-col gap-3">
+          <p class="text-body text-dark-charcoal leading-snug">{selfHostFree.description}</p>
+          <a
+            href={`${localizedPath(locale, '/self-hosted')}#under-the-hood`}
+            class="text-caption text-brand-blue hover:underline self-start"
+          >
+            {p.selfHost.controlPlaneLink}
+          </a>
+        </div>
         <ul class="flex flex-col gap-2 text-body text-dark-charcoal list-none p-0">
           {selfHostFree.features.map((feature) => (
             <li class="flex gap-2 items-start">

--- a/src/pages/pt-br/plans.astro
+++ b/src/pages/pt-br/plans.astro
@@ -123,7 +123,15 @@ const selfHostFree = p.selfHost.free;
         </div>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-10">
-        <p class="text-body text-dark-charcoal leading-snug">{selfHostFree.description}</p>
+        <div class="flex flex-col gap-3">
+          <p class="text-body text-dark-charcoal leading-snug">{selfHostFree.description}</p>
+          <a
+            href={`${localizedPath(locale, '/self-hosted')}#under-the-hood`}
+            class="text-caption text-brand-blue hover:underline self-start"
+          >
+            {p.selfHost.controlPlaneLink}
+          </a>
+        </div>
         <ul class="flex flex-col gap-2 text-body text-dark-charcoal list-none p-0">
           {selfHostFree.features.map((feature) => (
             <li class="flex gap-2 items-start">


### PR DESCRIPTION
## Summary
- `/plans` self-host card now has an inline "Don't know what a control plane is?" link that deep-links to the selfHosted page's explainer.
- The `<details>` block on `/self-hosted` opens automatically on `#under-the-hood` (hash on load + `hashchange`).
- New `pricing.selfHost.controlPlaneLink` i18n key in `en.json` and `pt-br.json`. pt-br translates "control plane" to "camada de controle", matching the rest of the pt-br copy (under-the-hood explainer, FAQ, plans description).

## Closes
Closes #174

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings, 2 pre-existing hints.
- [x] `npm run build` — clean.
- [x] Built HTML inspection: link present at `/plans` (`/self-hosted#under-the-hood`) and `/pt-br/plans` (`/pt-br/self-hosted#under-the-hood`); `id="under-the-hood"` present on the details element of both selfHosted pages; minified hash-open script present in both bundles.
- [ ] Manual: click link from `/plans` → lands on `/self-hosted#under-the-hood` with details open and section in view.
- [ ] Manual: visit `/self-hosted` directly with no hash → details stays closed.
- [ ] Manual: reload `/self-hosted#under-the-hood` → details opens on load.
- [ ] Manual: keyboard tab to link → global focus ring visible.

## Visual verification (UI changes only)
Visual verification not performed in a browser by the agent; behavior was confirmed via built-HTML inspection. Manual breakpoint check (375px, 768px, 1280px) recommended before merge.

## Notes
- No new dependencies. No `package.json` change.
- Forward-compat: kept the link inline rather than extracting a helper component, per the issue's "wait for a third use" guidance.