### PR TITLE
fix(vercel): keep .com.br asset paths same-origin to avoid CSP block

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,30 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [
     {
+      "source": "/_astro/:path*",
+      "has": [{ "type": "host", "value": "syncologic.com.br" }],
+      "destination": "https://syncologic.com/_astro/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/_astro/:path*",
+      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
+      "destination": "https://syncologic.com/_astro/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/api/:path*",
+      "has": [{ "type": "host", "value": "syncologic.com.br" }],
+      "destination": "https://syncologic.com/api/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/api/:path*",
+      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
+      "destination": "https://syncologic.com/api/:path*",
+      "permanent": true
+    },
+    {
       "source": "/:path*",
       "has": [{ "type": "host", "value": "syncologic.com.br" }],
       "destination": "https://syncologic.com/pt-br/:path*",


### PR DESCRIPTION
## Summary

Production hotfix: `https://syncologic.com.br/` was rendering as unstyled HTML because the catch-all `.com.br → .com/pt-br` redirect also caught `/_astro/*` paths. The cross-origin redirect (.com.br → .com) violates the strict CSP — `style-src 'self'` resolves to `.com.br` on the initial document, and `.com` is not in the source list, so the browser blocks the stylesheet.

Browser console (confirmed by user):

> Loading the stylesheet 'https://syncologic.com/pt-br/_astro/Footer.BrBstmP3.css' violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline' fonts.googleapis.com"

The trigger was a stale edge cache at `.com.br/` serving a previous deployment's HTML body (200) instead of the new 308 redirect. With the document not redirecting, the browser stayed on `.com.br` and tried to load same-origin assets, which then hit the cross-origin redirect rule and got blocked by CSP.

## Fix

Add explicit per-host redirects for `/_astro/*` and `/api/*` that strip the `/pt-br` prefix, so asset/API paths land on `.com/_astro/*` and `.com/api/*` (where they actually exist). These rules are placed before the existing `/:path*` catch-all so they win order-of-evaluation.

Steady-state behavior is unchanged — once the document-level redirect fires, the browser is on `.com/pt-br/` and assets load same-origin to `.com`. This is defense-in-depth for any future stale-HTML or partial-cache scenario.

## Test plan
- [ ] Vercel preview deploy is green (vercel.json-only change, no build impact expected)
- [ ] After merge to development + promotion to main + cache purge: `curl -I https://syncologic.com.br/` returns 308 to `https://syncologic.com/pt-br/`
- [ ] `curl -I https://syncologic.com.br/_astro/whatever.css` returns 308 to `https://syncologic.com/_astro/whatever.css` (no `/pt-br/`)
- [ ] Load `https://syncologic.com.br/` in a browser — should land on `.com/pt-br/` with full styling, no CSP errors in console