### PR TITLE
deploy: hotfix .com.br asset redirect CSP block

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,30 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [
     {
+      "source": "/_astro/:path*",
+      "has": [{ "type": "host", "value": "syncologic.com.br" }],
+      "destination": "https://syncologic.com/_astro/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/_astro/:path*",
+      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
+      "destination": "https://syncologic.com/_astro/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/api/:path*",
+      "has": [{ "type": "host", "value": "syncologic.com.br" }],
+      "destination": "https://syncologic.com/api/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/api/:path*",
+      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
+      "destination": "https://syncologic.com/api/:path*",
+      "permanent": true
+    },
+    {
       "source": "/:path*",
       "has": [{ "type": "host", "value": "syncologic.com.br" }],
       "destination": "https://syncologic.com/pt-br/:path*",


### PR DESCRIPTION
## Summary

Promotes the `.com.br` asset-redirect hotfix (#180) from `development` to `main` for production deploy.

Single commit: `vercel.json` adds explicit `/_astro/*` and `/api/*` redirects per host that keep asset/API paths same-origin to `.com`, placed before the existing page catch-all. Steady-state behavior unchanged; this is defense-in-depth for stale-HTML or partial-cache scenarios.

See #180 for full diagnosis (CSP cross-origin block on stylesheet redirect from `.com.br` → `.com/pt-br`).

## Post-merge action required
- Purge `syncologic.com.br` edge cache in Vercel so the stale-HTML response stops being served.

## Test plan
- [ ] After merge + production deploy + cache purge: `curl -I https://syncologic.com.br/` returns 308 to `https://syncologic.com/pt-br/`
- [ ] `curl -I https://syncologic.com.br/_astro/whatever.css` returns 308 to `https://syncologic.com/_astro/whatever.css` (no `/pt-br/`)
- [ ] Browser: `https://syncologic.com.br/` lands on `.com/pt-br/` with full styling, no CSP errors in console