### PR TITLE
fix(vercel): redirect .com.br to .com/pt-br including bare root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,27 +2,15 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [
     {
-      "source": "/_astro/:path*",
+      "source": "/",
       "has": [{ "type": "host", "value": "syncologic.com.br" }],
-      "destination": "https://syncologic.com/_astro/:path*",
+      "destination": "https://syncologic.com/pt-br/",
       "permanent": true
     },
     {
-      "source": "/_astro/:path*",
+      "source": "/",
       "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
-      "destination": "https://syncologic.com/_astro/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/api/:path*",
-      "has": [{ "type": "host", "value": "syncologic.com.br" }],
-      "destination": "https://syncologic.com/api/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/api/:path*",
-      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
-      "destination": "https://syncologic.com/api/:path*",
+      "destination": "https://syncologic.com/pt-br/",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary

Replaces the prior `.com.br` redirect logic with a clean `→ .com/pt-br/` rule that also covers the bare root path.

### What changed
- **Add explicit `/` rule per host** — `path-to-regexp`'s `/:path*` does not match the bare root `/`, so the previous catch-all let Vercel serve the static `index.html` at `.com.br/`. Explicit `/ → .com/pt-br/` fixes that.
- **Drop `/_astro/*` and `/api/*` carve-outs from the previous hotfix** — with the document-level redirect always firing, the browser lands on `.com/pt-br/` and asset URLs (e.g. `/_astro/foo.css`) resolve same-origin to `.com`. No cross-origin asset redirect is ever taken, so the CSP block doesn't apply.

### Required action outside this PR
Remove the Vercel project's domain-level redirect on `syncologic.com.br` and `www.syncologic.com.br` (Project → Settings → Domains). The Vercel-level redirect strips the path and currently overrides `vercel.json`, sending traffic to bare `.com/` instead of `.com/pt-br/`. Vercel's domain UI does not support path-injection (`.com/pt-br`), which is why this has to live in `vercel.json`.

## Test plan
After merging to development → main, deploying, and removing the Vercel-level domain redirect:
- [ ] `curl -I https://syncologic.com.br/` → 308 → `https://syncologic.com/pt-br/`
- [ ] `curl -I https://syncologic.com.br/use-cases/cloud-to-cloud-transfer` → 308 → `https://syncologic.com/pt-br/use-cases/cloud-to-cloud-transfer`
- [ ] `curl -I https://www.syncologic.com.br/` → 308 → `https://syncologic.com/pt-br/`
- [ ] Browser: `https://syncologic.com.br/` lands on `.com/pt-br/` with full styling, no CSP errors in console