### PR TITLE
deploy: .com.br redirect fix (root + clean /pt-br routing)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,27 +2,15 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [
     {
-      "source": "/_astro/:path*",
+      "source": "/",
       "has": [{ "type": "host", "value": "syncologic.com.br" }],
-      "destination": "https://syncologic.com/_astro/:path*",
+      "destination": "https://syncologic.com/pt-br/",
       "permanent": true
     },
     {
-      "source": "/_astro/:path*",
+      "source": "/",
       "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
-      "destination": "https://syncologic.com/_astro/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/api/:path*",
-      "has": [{ "type": "host", "value": "syncologic.com.br" }],
-      "destination": "https://syncologic.com/api/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/api/:path*",
-      "has": [{ "type": "host", "value": "www.syncologic.com.br" }],
-      "destination": "https://syncologic.com/api/:path*",
+      "destination": "https://syncologic.com/pt-br/",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary

Promotes #182 from `development` to `main` for production deploy.

Replaces the `.com.br` redirect logic in `vercel.json`:
- Adds explicit `/ → .com/pt-br/` per host (path-to-regexp's `/:path*` doesn't match bare root).
- Drops the `/_astro/*` and `/api/*` carve-outs from the previous hotfix — unnecessary once the document-level redirect always fires.

## Required after merge
1. Wait for production deploy to finish.
2. **In Vercel project settings → Domains**, remove the existing domain-level redirect on `syncologic.com.br` and `www.syncologic.com.br`. That Vercel-level rule currently strips the path and overrides `vercel.json`, which is why `.com.br/foo` was going to `.com/foo` instead of `.com/pt-br/foo`. Vercel's UI doesn't support path-injection, so the redirect has to live in `vercel.json`.
3. Purge edge cache for `.com.br`.

## Test plan
- [ ] `curl -I https://syncologic.com.br/` → 308 → `https://syncologic.com/pt-br/`
- [ ] `curl -I https://syncologic.com.br/use-cases/cloud-to-cloud-transfer` → 308 → `https://syncologic.com/pt-br/use-cases/cloud-to-cloud-transfer`
- [ ] `curl -I https://www.syncologic.com.br/` → 308 → `https://syncologic.com/pt-br/`
- [ ] Browser: `https://syncologic.com.br/` lands on `.com/pt-br/` with full styling, no CSP errors