### PR TITLE
fix(email): hedge segmentation CTA so users who already answered aren't confused

### DIFF
--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -121,7 +121,9 @@ function renderEmail(p: ConfirmationParams, c: Copy): string {
                   <tr>
                     <td style="padding:20px 24px;">
                       <p style="margin:0 0 12px 0;font-size:15px;line-height:1.5;color:${COLOR.text};">${c.segPrompt}</p>
-                      <a href="${segHref}" style="display:inline-block;padding:12px 22px;background:${COLOR.brand};color:#FFFFFF;font-size:15px;font-weight:500;line-height:1;text-decoration:none;border-radius:100px;">${c.segCta}</a>
+                      <div style="text-align:center;">
+                        <a href="${segHref}" style="display:inline-block;padding:12px 22px;background:${COLOR.brand};color:#FFFFFF;font-size:15px;font-weight:500;line-height:1;text-decoration:none;border-radius:100px;">${c.segCta}</a>
+                      </div>
                       <p style="margin:14px 0 0 0;font-size:13px;line-height:1.5;color:${COLOR.muted};">${c.segNote}</p>
                     </td>
                   </tr>

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -25,6 +25,7 @@ interface Copy {
   intro: string;
   segPrompt: string;
   segCta: string;
+  segNote: string;
   signoff: string;
   team: string;
   unsubPrompt: string;
@@ -41,6 +42,8 @@ const COPY: Record<Locale, Copy> = {
       "Thanks for joining the Syncologic waitlist. We're building the calmest way to move files between clouds — and we're genuinely happy you're here. We'll only email when there's something real to try. No noise in between.",
     segPrompt: 'If you have 30 seconds, help us build the right thing first:',
     segCta: 'Tell us what you want to move →',
+    segNote:
+      "This button takes you to the questions shown after you entered your email. If you already answered them on the page, you're good. If not, your answers help us build the best product for you.",
     signoff: 'Talk soon,',
     team: 'The Syncologic team',
     unsubPrompt: "Didn't sign up?",
@@ -55,6 +58,8 @@ const COPY: Record<Locale, Copy> = {
       'Obrigado por entrar na lista de espera da Syncologic. Estamos construindo o jeito mais tranquilo de mover arquivos entre nuvens — e ficamos felizes de verdade com você aqui. Só vamos te escrever quando tiver algo de verdade para experimentar. Nada de spam.',
     segPrompt: 'Se tiver 30 segundos, nos ajude a construir a coisa certa primeiro:',
     segCta: 'Conta o que você quer transferir →',
+    segNote:
+      'Este botão leva você às perguntas que aparecem depois que você digita seu e-mail. Se você já respondeu na página, está tudo certo. Se não, suas respostas ajudam a gente a construir o melhor produto para você.',
     signoff: 'Até breve,',
     team: 'A equipe da Syncologic',
     unsubPrompt: 'Não foi você?',
@@ -117,6 +122,7 @@ function renderEmail(p: ConfirmationParams, c: Copy): string {
                     <td style="padding:20px 24px;">
                       <p style="margin:0 0 12px 0;font-size:15px;line-height:1.5;color:${COLOR.text};">${c.segPrompt}</p>
                       <a href="${segHref}" style="display:inline-block;padding:12px 22px;background:${COLOR.brand};color:#FFFFFF;font-size:15px;font-weight:500;line-height:1;text-decoration:none;border-radius:100px;">${c.segCta}</a>
+                      <p style="margin:14px 0 0 0;font-size:13px;line-height:1.5;color:${COLOR.muted};">${c.segNote}</p>
                     </td>
                   </tr>
                 </table>


### PR DESCRIPTION
## Summary
- Add a small muted note inside the segmentation block of the waitlist confirmation email, directly below the CTA, in both EN and pt-BR.
- Explains what the button does and that users who already answered the questions on the page can ignore it.
- Email template only — no DB, API, or front-end change.

## Closes
Closes #184

## Test plan
- [x] `npm run lint` — clean (0 errors, only pre-existing hints in unchanged files)
- [x] `npm run build` — clean
- [ ] **Manual: send a real confirmation email** in both locales (e.g. via the live waitlist form or a Resend dashboard test send) and confirm the new note renders correctly in Gmail web + at least one mobile client. This couldn't be exercised from the worktree without producing a real Resend send.

## Visual verification (UI changes only)
Visual verification not performed in-PR — the change is in transactional email HTML, which can't be reliably previewed in a browser. The note uses existing tokens (`COLOR.muted`, 13px, line-height 1.5) and sits inside the existing brand-soft block, so layout risk is low; the `## Test plan` item above gates merge on a real send.

## Notes
- No deps changed.
- Copy added under a new `segNote` field on the `Copy` interface in `src/lib/resend.ts`, populated for both `en` and `pt-br`.
- This is the lightweight ship-today fix discussed with the dev. The fuller alternatives (delayed conditional send, smart redirect link) are deliberately out of scope and can be revisited in a separate issue if signal warrants.
