### PR TITLE
fix(csp): allow Switzer from fontshare

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -52,7 +52,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' va.vercel-scripts.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; img-src 'self' data:; connect-src 'self' va.vercel-scripts.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' va.vercel-scripts.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com api.fontshare.com; font-src 'self' fonts.gstatic.com cdn.fontshare.com; img-src 'self' data:; connect-src 'self' va.vercel-scripts.com api.fontshare.com cdn.fontshare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
         }
       ]
     }


### PR DESCRIPTION
## Summary

\`src/styles/global.css\` imports Switzer from \`api.fontshare.com\`, with font binaries served from \`cdn.fontshare.com\`. Neither host was in the CSP, so the browser was blocking the stylesheet and the woff2s in production — Switzer never loaded.

This adds the two fontshare hosts to \`style-src\`, \`font-src\`, and \`connect-src\` (the last covers the preconnect hint in \`Layout.astro\`). Targeting \`main\` directly because it's a one-line production hotfix.

## Test plan

- [ ] After deploy, DevTools → Network: \`api.fontshare.com/v2/css?...\` returns 200, no CSP violation
- [ ] DevTools → Console: no \"Refused to load the stylesheet/font ... violates the following Content Security Policy directive\" warnings
- [ ] Body copy on \`/\` renders in Switzer (not the system fallback)